### PR TITLE
Clean up Event handling.

### DIFF
--- a/surface_factory_wayland.cc
+++ b/surface_factory_wayland.cc
@@ -107,7 +107,6 @@ gfx::AcceleratedWidget SurfaceFactoryWayland::GetAcceleratedWidget() {
 
   window = new ui::WaylandWindow(display_);
   window->SetParentWindow(NULL);
-  window->Flush();
 
   return (gfx::AcceleratedWidget)window;
 }

--- a/wayland_display.h
+++ b/wayland_display.h
@@ -69,7 +69,19 @@ class WaylandDisplay {
 
   void AddTask(WaylandTask* task);
 
-  void ProcessTasks();
+  // Returns true if any pending tasks have been handled otherwise
+  // returns false.
+  bool ProcessTasks();
+
+  // Handles any pending Wayland tasks and sends
+  // all buffered data on client side to the server.
+  // The call has no effect if there are no pending
+  // WaylandTasks.
+  void FlushTasks();
+
+  // Handles any pending Wayland tasks and sends
+  // all buffered data on client side to the server.
+  void Flush();
 
   void SetPointerImage(WaylandInputDevice* device, int pointer);
 
@@ -83,8 +95,8 @@ class WaylandDisplay {
 
  private:
   void CreateCursors();
-
   void DestroyCursors();
+  void scheduleFlush() { handle_flush_ = true; }
 
   // This handler resolves all server events used in initialization. It also
   // handles input device registration, screen registration.
@@ -112,7 +124,9 @@ class WaylandDisplay {
 
   wl_cursor_theme *cursor_theme_;
   wl_cursor **cursors_;
+  bool handle_flush_ :1;
 
+  friend class WaylandWindow;
   DISALLOW_COPY_AND_ASSIGN(WaylandDisplay);
 };
 

--- a/wayland_task.cc
+++ b/wayland_task.cc
@@ -34,18 +34,4 @@ void WaylandResizeTask::Run()
   window_->OnResize();
 }
 
-////////////////// WaylandRedrawTask Implementation ////////////////////////////
-WaylandRedrawTask::WaylandRedrawTask(WaylandWindow *window) : WaylandTask(window)
-{
-}
-
-WaylandRedrawTask::~WaylandRedrawTask()
-{
-}
-
-void WaylandRedrawTask::Run()
-{
-  window_->OnRedraw();
-}
-
 }  // namespace ui

--- a/wayland_task.h
+++ b/wayland_task.h
@@ -49,16 +49,6 @@ class WaylandResizeTask : public WaylandTask {
   DISALLOW_COPY_AND_ASSIGN(WaylandResizeTask);
 };
 
-class WaylandRedrawTask : public WaylandTask {
- public:
-  WaylandRedrawTask(WaylandWindow* window);
-  virtual ~WaylandRedrawTask();
-  virtual void Run();
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(WaylandRedrawTask);
-};
-
 }  // namespace ui
 
 #endif  // OZONE_WAYLAND_TASK_H_

--- a/wayland_window.h
+++ b/wayland_window.h
@@ -55,15 +55,13 @@ class WaylandWindow {
 
   void SetBounds(const gfx::Rect& new_bounds);
   gfx::Rect GetBounds() const;
-  void Flush();
   void GetResizeDelta(int &x, int &y);
 
   void ScheduleResize(int32_t width, int32_t height);
   void SchedulePaintInRect(const gfx::Rect& rect);
-  void ScheduleRedraw();
+  void ScheduleFlush();
 
   virtual void OnResize();
-  virtual void OnRedraw();
 
   const Windows& GetChildren() const { return children_; }
   void AddChild(WaylandWindow* child);
@@ -133,7 +131,6 @@ class WaylandWindow {
   gfx::Rect pending_allocation_;
   WindowType type_;
   bool resize_scheduled_;
-  bool redraw_scheduled_;
   wl_egl_window *window_;
 
   // Child windows. Topmost is last.


### PR DESCRIPTION
We currently have too many places where display is flushed for various reasons.
The patch does the following changes:
1)Make all code related to flushing display internal to WaylandDisplay.
2)Avoid need to flush in WaylandWindow.
3)In certain cases we need to flush display only if any pending WaylandTasks have been handled else we dont have to.
