### PR TITLE
Simplify retrieveing primary screen attributes.

### DIFF
--- a/surface_factory_wayland.cc
+++ b/surface_factory_wayland.cc
@@ -133,10 +133,7 @@ gfx::AcceleratedWidget SurfaceFactoryWayland::RealizeAcceleratedWidget(
 }
 
 const char* SurfaceFactoryWayland::DefaultDisplaySpec() {
-  // (kalyan) We could track active mode of front screen
-  // instead of having to go through the modes on every call.
-  std::list<ui::WaylandScreen*> screens = WaylandDisplay::GetDisplay()->GetScreenList();
-  gfx::Rect scrn = screens.front()->GetAllocation();
+  gfx::Rect scrn = WaylandDisplay::GetDisplay()->PrimaryScreen()->Geometry();
   int size = 2 * sizeof scrn.width();
   if (!spec_)
     spec_ = new char[size];

--- a/wayland_display.cc
+++ b/wayland_display.cc
@@ -50,6 +50,7 @@ WaylandDisplay::WaylandDisplay(char* name) : display_(NULL),
     shell_(NULL),
     shm_(NULL),
     queue_(NULL),
+    primary_screen_(NULL),
     handle_flush_(false)
 {
   display_ = wl_display_connect(name);
@@ -273,6 +274,8 @@ void WaylandDisplay::DisplayHandleGlobal(void *data,
   } else if (strcmp(interface, "wl_output") == 0) {
     WaylandScreen* screen = new WaylandScreen(disp, name);
     disp->screen_list_.push_back(screen);
+    // (kalyan) Support extended output.
+    disp->primary_screen_ = disp->screen_list_.front();
   } else if (strcmp(interface, "wl_seat") == 0) {
     WaylandInputDevice *input_device = new WaylandInputDevice(disp, name);
     disp->input_list_.push_back(input_device);

--- a/wayland_display.h
+++ b/wayland_display.h
@@ -42,6 +42,7 @@ class WaylandDisplay {
 
   // Returns a list of the registered screens.
   std::list<WaylandScreen*> GetScreenList() const;
+  WaylandScreen* PrimaryScreen() const { return primary_screen_ ; }
 
   wl_shell* shell() const { return shell_; }
 
@@ -110,6 +111,7 @@ class WaylandDisplay {
   wl_shell* shell_;
   wl_shm* shm_;
   struct wl_event_queue* queue_;
+  WaylandScreen* primary_screen_;
 
   std::list<WaylandScreen*> screen_list_;
   std::list<WaylandInputDevice*> input_list_;

--- a/wayland_screen.h
+++ b/wayland_screen.h
@@ -27,20 +27,9 @@ class WaylandScreen {
   ~WaylandScreen();
 
   // Returns the active allocation of the screen.
-  gfx::Rect GetAllocation() const;
+  gfx::Rect Geometry() const;
 
  private:
-  // Used to store information regarding the available modes for the current
-  // screen.
-  // - (width, height): is the resolution of the screen
-  // - refresh: is the refresh rate of the screen under this mode
-  // - flags: contains extra information regarding the mode. The most important
-  //          is the active mode flag.
-  struct Mode {
-    int32_t width, height, refresh, flags;
-  };
-  typedef std::list<Mode> Modes;
-
   // Callback functions that allows the display to initialize the screen's
   // position and available modes.
   static void OutputHandleGeometry(void* data,
@@ -56,14 +45,13 @@ class WaylandScreen {
 
   // The Wayland output this object wraps
   wl_output* output_;
-  // The display that the output is associated with
-  WaylandDisplay* display_;
   // The position of the screen. This is important in multi monitor display
   // since it provides the position of the screen in the virtual screen.
   gfx::Point position_;
 
-  // List of supported modes
-  Modes modes_;
+  // Rect and Refresh rate of active mode.
+  gfx::Rect rect_;
+  int32_t refresh_;
 
   DISALLOW_COPY_AND_ASSIGN(WaylandScreen);
 };


### PR DESCRIPTION
In DefaultDisplaySpec we retrieve the first screen in screen list, check
all available modes. The attibutes of first mode with WL_OUTPUT_MODE_CURRENT
enabled are retrieved as geometry of screen. The patch introduces
the concept of primary screen (output). The api is part of WaylandDisplay
and logic to decide which is primary screen is internal to WaylandDisplay.
Currently, first screen in screen_list is always primary screen.
We dont have to store all modes of screen but only last mode with
WL_OUTPUT_MODE_CURRENT flag enabled.
