### PR TITLE
Memory Leak fix.

### DIFF
--- a/desktop_screen_wayland.cc
+++ b/desktop_screen_wayland.cc
@@ -24,6 +24,7 @@ gfx::Size GetPrimaryDisplaySize() {
 }
 }  // namespace
 
+namespace ui {
 DesktopScreenWayland::DesktopScreenWayland() {
 }
 
@@ -69,4 +70,6 @@ void DesktopScreenWayland::AddObserver(gfx::DisplayObserver* observer) {
 }
 
 void DesktopScreenWayland::RemoveObserver(gfx::DisplayObserver* observer) {
+}
+
 }

--- a/desktop_screen_wayland.h
+++ b/desktop_screen_wayland.h
@@ -7,6 +7,7 @@
 
 #include "ui/gfx/screen.h"
 
+namespace ui {
 class DesktopScreenWayland : public gfx::Screen {
  public:
   DesktopScreenWayland();
@@ -30,5 +31,6 @@ class DesktopScreenWayland : public gfx::Screen {
 
   DISALLOW_COPY_AND_ASSIGN(DesktopScreenWayland);
 };
+}
 
 #endif  // DESKTOP_SCREEN_WAYLAND_H__

--- a/surface_factory_wayland.cc
+++ b/surface_factory_wayland.cc
@@ -82,7 +82,8 @@ void SurfaceFactoryWayland::InitializeWaylandEvent()
 }
 
 SurfaceFactoryWayland::SurfaceFactoryWayland()
-    : e_factory(NULL),
+    : desktop_screen_(NULL),
+      e_factory(NULL),
       root_window_(NULL),
       spec_(NULL)
 {
@@ -107,6 +108,11 @@ void SurfaceFactoryWayland::ShutdownHardware() {
   if (root_window_) {
     delete root_window_;
     root_window_ =NULL;
+  }
+
+  if (desktop_screen_)  {
+    delete desktop_screen_;
+    desktop_screen_ = NULL;
   }
 
   WaylandDisplay::DestroyDisplay();
@@ -147,7 +153,10 @@ const char* SurfaceFactoryWayland::DefaultDisplaySpec() {
 }
 
 gfx::Screen* SurfaceFactoryWayland::CreateDesktopScreen() {
-  return new DesktopScreenWayland;
+  if (!desktop_screen_)
+    desktop_screen_ = new DesktopScreenWayland();
+
+  return (gfx::Screen*)desktop_screen_;
 }
 
 bool SurfaceFactoryWayland::LoadEGLGLES2Bindings() {

--- a/surface_factory_wayland.h
+++ b/surface_factory_wayland.h
@@ -12,6 +12,7 @@ namespace ui {
 
 class WaylandDisplay;
 class WaylandWindow;
+class DesktopScreenWayland;
 class EventFactoryWayland;
 
 class SurfaceFactoryWayland : public SurfaceFactoryOzone {
@@ -35,6 +36,7 @@ class SurfaceFactoryWayland : public SurfaceFactoryOzone {
  private:
   void InitializeWaylandEvent();
 
+  DesktopScreenWayland* desktop_screen_;
   EventFactoryWayland* e_factory;
   WaylandWindow* root_window_;
   char* spec_;


### PR DESCRIPTION
We allocate DesktopScreenWayland object but never delete the object.
Now, SurfaceFactoryWayland is responsible for the construction and
destruction of DesktopScreenWayland.
