### PR TITLE
Make display connection in InitializeHardware.

### DIFF
--- a/impl/desktop_root_window_host_wayland.cc
+++ b/impl/desktop_root_window_host_wayland.cc
@@ -76,8 +76,17 @@ ui::NativeTheme* DesktopRootWindowHost::GetNativeTheme(aura::Window* window) {
 void DesktopRootWindowHostWayland::InitWaylandWindow(
     const Widget::InitParams& params) {
 
-  window_ = ui::SurfaceFactoryOzone::GetInstance()->GetAcceleratedWidget();
-  ui::SurfaceFactoryOzone::GetInstance()->AttemptToResizeAcceleratedWidget(window_, params.bounds);
+  ui::SurfaceFactoryOzone* surface_factory =
+          ui::SurfaceFactoryOzone::GetInstance();
+  ui::SurfaceFactoryOzone::HardwareState displayInitialization =
+          surface_factory->InitializeHardware();
+  if (displayInitialization != ui::SurfaceFactoryOzone::INITIALIZED) {
+    LOG(ERROR) << "DesktopRootWindowHostWayland failed to initialize hardware";
+    return;
+  }
+
+  window_ = surface_factory->GetAcceleratedWidget();
+  surface_factory->AttemptToResizeAcceleratedWidget(window_, params.bounds);
 }
 
 void DesktopRootWindowHostWayland::HandleNativeWidgetActivationChanged(

--- a/impl/surface_factory_wayland.cc
+++ b/impl/surface_factory_wayland.cc
@@ -86,7 +86,6 @@ SurfaceFactoryWayland::SurfaceFactoryWayland()
       root_window_(NULL),
       spec_(NULL)
 {
-  WaylandDisplay::Connect();
   LOG(INFO) << "Ozone: SurfaceFactoryWayland";
 }
 
@@ -100,6 +99,9 @@ SurfaceFactoryWayland::~SurfaceFactoryWayland()
 
 SurfaceFactoryOzone::HardwareState SurfaceFactoryWayland::InitializeHardware()
 {
+  if (!WaylandDisplay::GetDisplay())
+    WaylandDisplay::Connect();
+
   return WaylandDisplay::GetDisplay()->display() ? SurfaceFactoryOzone::INITIALIZED : SurfaceFactoryOzone::FAILED;
 }
 


### PR DESCRIPTION
We always open a new wayland connection
in surface_factory_wayland constructor. This is
confusing as it should happen in InitializeHardware
api call, also it would prevent any un-necessary
display connections. This patch makes appropriate changes
in this direction.
