### PR TITLE
EventFactoryWayland should observe message loop destruction.

### DIFF
--- a/impl/event_factory_wayland.cc
+++ b/impl/event_factory_wayland.cc
@@ -30,12 +30,9 @@ EventFactoryWayland::EventFactoryWayland()
   CHECK(success);
 
   dis->FlushTasks();
-  loop_ = base::MessageLoop::current();
-
-  if (loop_) {
-    loop_->AddDestructionObserver(this);
-    loop_->AddTaskObserver(this);
-  }
+  DCHECK(base::MessageLoop::current());
+  base::MessageLoop::current()->AddDestructionObserver(this);
+  base::MessageLoop::current()->AddTaskObserver(this);
 }
 
 EventFactoryWayland::~EventFactoryWayland() {
@@ -84,12 +81,9 @@ void EventFactoryWayland::DidProcessTask(
 void EventFactoryWayland::WillDestroyCurrentMessageLoop()
 {
   DCHECK(base::MessageLoop::current());
-  if (loop_) {
     watcher_.StopWatchingFileDescriptor();
     base::MessageLoop::current()->RemoveDestructionObserver(this);
     base::MessageLoop::current()->RemoveTaskObserver(this);
-    loop_ = NULL;
-  }
 }
 
 }  // namespace ui

--- a/impl/event_factory_wayland.h
+++ b/impl/event_factory_wayland.h
@@ -39,7 +39,6 @@ class EventFactoryWayland : public base::MessageLoop::TaskObserver,
   virtual void DidProcessTask(const base::PendingTask& pending_task) OVERRIDE;
 
   int fd_;
-  base::MessageLoop* loop_;
   base::MessagePumpLibevent::FileDescriptorWatcher watcher_;
 };
 


### PR DESCRIPTION
EventFactoryWayland registers itself for observing
any processed tasks but is never removed from the list.
Expectation here is that it would be cleaned up during
exit phase. Correct solution would be to make
EventFactoryWayland register as destruction observer
of the message loop.

Now, EventFactoryWayland adds itself to destruction
observer list and does proper de-registrations when
the message loop is about to be destroyed.
