### PR TITLE
Un-necessary call to FlushTasks in EventFactoryWayland constructor.

### DIFF
--- a/impl/event_factory_wayland.cc
+++ b/impl/event_factory_wayland.cc
@@ -28,8 +28,6 @@ EventFactoryWayland::EventFactoryWayland()
                             &watcher_,
                             this);
   CHECK(success);
-
-  dis->FlushTasks();
   DCHECK(base::MessageLoop::current());
   base::MessageLoop::current()->AddDestructionObserver(this);
   base::MessageLoop::current()->AddTaskObserver(this);


### PR DESCRIPTION
FLushTasks would handle any pending wayland tasks and flush
wl_display. Calling this has no effect in case of no
pending wayland tasks. We call this from EventFactoryWayland
consructor. This call seems un-necessary and doesn't have
any effect as there would be no pending tasks during initialization
phase.
