### PR TITLE
Add loader file.

### DIFF
--- a/impl/surface_factory_wayland.cc
+++ b/impl/surface_factory_wayland.cc
@@ -16,62 +16,7 @@
 #include "ozone/wayland/display.h"
 #include "ozone/wayland/window.h"
 #include "ozone/wayland/screen.h"
-#include "ui/gl/gl_bindings.h"
-#include "ui/gl/gl_egl_api_implementation.h"
-#include "ui/gl/gl_gl_api_implementation.h"
-#include "ui/gl/gl_implementation.h"
-#include "ui/gl/gl_switches.h"
-
-namespace gfx {
-namespace {
-
-// Load a library, printing an error message on failure.
-base::NativeLibrary LoadLibrary(const base::FilePath& filename) {
-  std::string error;
-  base::NativeLibrary library = base::LoadNativeLibrary(filename,
-                                                        &error);
-  if (!library) {
-    DVLOG(1) << "Failed to load " << filename.MaybeAsASCII() << ": " << error;
-    return NULL;
-  }
-  return library;
-}
-
-base::NativeLibrary LoadLibrary(const char* filename) {
-  return LoadLibrary(base::FilePath(filename));
-}
-
-}  // namespace
-
-bool InitializeGLBindings() {
-  base::NativeLibrary gles_library = LoadLibrary("libGLESv2.so.2");
-  if (!gles_library)
-    return false;
-  base::NativeLibrary egl_library = LoadLibrary("libEGL.so.1");
-  if (!egl_library) {
-    base::UnloadNativeLibrary(gles_library);
-    return false;
-  }
-
-  GLGetProcAddressProc get_proc_address =
-      reinterpret_cast<GLGetProcAddressProc>(
-          base::GetFunctionPointerFromNativeLibrary(
-              egl_library, "eglGetProcAddress"));
-  if (!get_proc_address) {
-    LOG(ERROR) << "eglGetProcAddress not found.";
-    base::UnloadNativeLibrary(egl_library);
-    base::UnloadNativeLibrary(gles_library);
-    return false;
-  }
-
-  SetGLGetProcAddressProc(get_proc_address);
-  AddGLNativeLibrary(egl_library);
-  AddGLNativeLibrary(gles_library);
-
-  return true;
-}
-
-}  // namespace gfx
+#include "ozone/wayland/egl/loader.h"
 
 namespace ui {
 

--- a/ozone_impl.gyp
+++ b/ozone_impl.gyp
@@ -38,6 +38,7 @@
         '../base/base.gyp:base',
         '../base/base.gyp:base_i18n',
         '../ui/compositor/compositor.gyp:compositor',
+        '../ui/gl/gl.gyp:gl',
         '../ui/ui.gyp:ui',
         '../ui/ui.gyp:ui_resources',
       ],
@@ -63,6 +64,8 @@
         "wayland/kbd_conversion.h",
         "wayland/keyboard.cc",
         "wayland/keyboard.h",
+        "wayland/egl/loader.h",
+        "wayland/egl/loader.cc",
         "wayland/pointer.cc",
         "wayland/pointer.h",
         'wayland/screen.cc',
@@ -80,7 +83,6 @@
       'type': 'static_library',
       'dependencies': [
         '<(DEPTH)/ui/ui.gyp:ui',
-        '<(DEPTH)/ui/gl/gl.gyp:gl',
         '<(DEPTH)/skia/skia.gyp:skia',
         'wayland_toolkit'
       ],

--- a/wayland/egl/loader.cc
+++ b/wayland/egl/loader.cc
@@ -1,0 +1,63 @@
+// Copyright 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/files/file_path.h"
+#include "base/native_library.h"
+#include "ui/gl/gl_bindings.h"
+#include "ui/gl/gl_egl_api_implementation.h"
+#include "ui/gl/gl_gl_api_implementation.h"
+#include "ui/gl/gl_implementation.h"
+#include "ui/gl/gl_switches.h"
+
+namespace gfx {
+
+namespace {
+
+// Load a library, printing an error message on failure.
+base::NativeLibrary LoadLibrary(const base::FilePath& filename) {
+  std::string error;
+  base::NativeLibrary library = base::LoadNativeLibrary(filename,
+                                                        &error);
+  if (!library) {
+    DVLOG(1) << "Failed to load " << filename.MaybeAsASCII() << ": " << error;
+    return NULL;
+  }
+  return library;
+}
+
+base::NativeLibrary LoadLibrary(const char* filename) {
+  return LoadLibrary(base::FilePath(filename));
+}
+
+}  // namespace
+
+bool InitializeGLBindings() {
+  base::NativeLibrary gles_library = LoadLibrary("libGLESv2.so.2");
+  if (!gles_library)
+    return false;
+  base::NativeLibrary egl_library = LoadLibrary("libEGL.so.1");
+  if (!egl_library) {
+    base::UnloadNativeLibrary(gles_library);
+    return false;
+  }
+
+  GLGetProcAddressProc get_proc_address =
+      reinterpret_cast<GLGetProcAddressProc>(
+          base::GetFunctionPointerFromNativeLibrary(
+              egl_library, "eglGetProcAddress"));
+  if (!get_proc_address) {
+    LOG(ERROR) << "eglGetProcAddress not found.";
+    base::UnloadNativeLibrary(egl_library);
+    base::UnloadNativeLibrary(gles_library);
+    return false;
+  }
+
+  SetGLGetProcAddressProc(get_proc_address);
+  AddGLNativeLibrary(egl_library);
+  AddGLNativeLibrary(gles_library);
+
+  return true;
+}
+
+}  // namespace gfx

--- a/wayland/egl/loader.h
+++ b/wayland/egl/loader.h
@@ -1,0 +1,10 @@
+// Copyright 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
+namespace gfx {
+
+bool InitializeGLBindings();
+
+}  // namespace gfx


### PR DESCRIPTION
This patch moves code specific to loading egl
libraries and bindings from surface_factory_wayland
to a separate file. This will be extended to support
wayland specific bindings like EGL_WL_bind_wayland_display
and eglUnbindWaylandDisplayWL.
