### PR TITLE
Move all classes to ozonewayland namespace.

### DIFF
--- a/impl/desktop_factory_wayland.cc
+++ b/impl/desktop_factory_wayland.cc
@@ -5,7 +5,7 @@
 #include "ozone/impl/desktop_factory_wayland.h"
 #include "ozone/impl/desktop_root_window_host_wayland.h"
 
-namespace views {
+namespace ozonewayland {
 
 DesktopFactoryWayland::DesktopFactoryWayland()
 {
@@ -16,13 +16,13 @@ DesktopFactoryWayland::~DesktopFactoryWayland()
 {
 }
 
-DesktopRootWindowHost* DesktopFactoryWayland::CreateRootWindowHost(
-    internal::NativeWidgetDelegate* native_widget_delegate,
-    DesktopNativeWidgetAura* desktop_native_widget_aura,
+views::DesktopRootWindowHost* DesktopFactoryWayland::CreateRootWindowHost(
+    views::internal::NativeWidgetDelegate* native_widget_delegate,
+    views::DesktopNativeWidgetAura* desktop_native_widget_aura,
     const gfx::Rect& bounds) {
   return new DesktopRootWindowHostWayland(native_widget_delegate,
                                           desktop_native_widget_aura,
                                           bounds);
 }
 
-}  // namespace views
+}  // namespace ozonewayland

--- a/impl/desktop_factory_wayland.h
+++ b/impl/desktop_factory_wayland.h
@@ -8,20 +8,20 @@
 #include "base/compiler_specific.h"
 #include "ui/views/widget/desktop_aura/desktop_factory_ozone.h"
 
-namespace views {
+namespace ozonewayland {
 
-class DesktopFactoryWayland : public DesktopFactoryOzone {
+class DesktopFactoryWayland : public views::DesktopFactoryOzone {
  public:
   DesktopFactoryWayland();
   virtual ~DesktopFactoryWayland();
 
   // views::DesktopFactoryOzone
-  virtual DesktopRootWindowHost* CreateRootWindowHost(
-      internal::NativeWidgetDelegate* native_widget_delegate,
-      DesktopNativeWidgetAura* desktop_native_widget_aura,
+  virtual views::DesktopRootWindowHost* CreateRootWindowHost(
+      views::internal::NativeWidgetDelegate* native_widget_delegate,
+      views::DesktopNativeWidgetAura* desktop_native_widget_aura,
       const gfx::Rect& bounds) OVERRIDE;
 };
 
-} // namespace views
+} // namespace ozonewayland
 
 #endif // OZONE_DESKTOP_FACTORY_WAYLAND_H_

--- a/impl/desktop_root_window_host_wayland.cc
+++ b/impl/desktop_root_window_host_wayland.cc
@@ -29,6 +29,23 @@
 #include "ui/views/widget/desktop_aura/desktop_screen_position_client.h"
 
 namespace views {
+// static
+ui::NativeTheme* DesktopRootWindowHost::GetNativeTheme(aura::Window* window) {
+  const views::LinuxUI* linux_ui = views::LinuxUI::instance();
+  if (linux_ui) {
+    ui::NativeTheme* native_theme = linux_ui->GetNativeTheme();
+    if (native_theme)
+      return native_theme;
+  }
+
+  return ui::NativeTheme::instance();
+}
+
+}
+
+namespace ozonewayland {
+
+using namespace views;
 
 DesktopRootWindowHostWayland* DesktopRootWindowHostWayland::g_current_capture =
     NULL;
@@ -53,18 +70,6 @@ DesktopRootWindowHostWayland::~DesktopRootWindowHostWayland() {
   root_window_->ClearProperty(kHostForRootWindow);
   aura::client::SetFocusClient(root_window_, NULL);
   aura::client::SetActivationClient(root_window_, NULL);
-}
-
-// static
-ui::NativeTheme* DesktopRootWindowHost::GetNativeTheme(aura::Window* window) {
-  const views::LinuxUI* linux_ui = views::LinuxUI::instance();
-  if (linux_ui) {
-    ui::NativeTheme* native_theme = linux_ui->GetNativeTheme();
-    if (native_theme)
-      return native_theme;
-  }
-
-  return ui::NativeTheme::instance();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -640,4 +645,4 @@ bool DesktopRootWindowHostWayland::Dispatch(const base::NativeEvent& ne) {
   return true;
 }
 
-}  // namespace views
+}  // namespace ozonewayland

--- a/impl/desktop_root_window_host_wayland.h
+++ b/impl/desktop_root_window_host_wayland.h
@@ -26,19 +26,21 @@ class DesktopDragDropClientAuraOzone;
 class DesktopDispatcherClient;
 class OzoneDesktopWindowMoveClient;
 class OzoneWindowEventFilter;
-
 namespace corewm {
 class CursorManager;
 }
+}
+
+namespace ozonewayland {
 
 class VIEWS_EXPORT DesktopRootWindowHostWayland :
-    public DesktopRootWindowHost,
+    public views::DesktopRootWindowHost,
     public aura::RootWindowHost,
     public base::MessageLoop::Dispatcher {
  public:
   DesktopRootWindowHostWayland(
-      internal::NativeWidgetDelegate* native_widget_delegate,
-      DesktopNativeWidgetAura* desktop_native_widget_aura,
+      views::internal::NativeWidgetDelegate* native_widget_delegate,
+      views::DesktopNativeWidgetAura* desktop_native_widget_aura,
       const gfx::Rect& bounds);
   virtual ~DesktopRootWindowHostWayland();
 
@@ -49,11 +51,11 @@ class VIEWS_EXPORT DesktopRootWindowHostWayland :
  private:
   // Initializes our Ozone surface to draw on. This method performs all
   // initialization related to talking to the Ozone server.
-  void InitWaylandWindow(const Widget::InitParams& params);
+  void InitWaylandWindow(const views::Widget::InitParams& params);
 
   // Creates an aura::RootWindow to contain the |content_window|, along with
   // all aura client objects that direct behavior.
-  aura::RootWindow* InitRootWindow(const Widget::InitParams& params);
+  aura::RootWindow* InitRootWindow(const views::Widget::InitParams& params);
 
   // Returns true if there's an X window manager present... in most cases.  Some
   // window managers (notably, ion3) don't implement enough of ICCCM for us to
@@ -71,7 +73,7 @@ class VIEWS_EXPORT DesktopRootWindowHostWayland :
 
   // Overridden from DesktopRootWindowHost:
   virtual aura::RootWindow* Init(aura::Window* content_window,
-                                 const Widget::InitParams& params) OVERRIDE;
+                                 const views::Widget::InitParams& params) OVERRIDE;
   virtual void InitFocus(aura::Window* window) OVERRIDE;
   virtual void Close() OVERRIDE;
   virtual void CloseNow() OVERRIDE;
@@ -102,14 +104,14 @@ class VIEWS_EXPORT DesktopRootWindowHostWayland :
   virtual void SetAlwaysOnTop(bool always_on_top) OVERRIDE;
   virtual void SetWindowTitle(const string16& title) OVERRIDE;
   virtual void ClearNativeFocus() OVERRIDE;
-  virtual Widget::MoveLoopResult RunMoveLoop(
+  virtual views::Widget::MoveLoopResult RunMoveLoop(
       const gfx::Vector2d& drag_offset,
-      Widget::MoveLoopSource source) OVERRIDE;
+      views::Widget::MoveLoopSource source) OVERRIDE;
   virtual void EndMoveLoop() OVERRIDE;
   virtual void SetVisibilityChangedAnimationsEnabled(bool value) OVERRIDE;
   virtual bool ShouldUseNativeFrame() OVERRIDE;
   virtual void FrameTypeChanged() OVERRIDE;
-  virtual NonClientFrameView* CreateNonClientFrameView() OVERRIDE;
+  virtual views::NonClientFrameView* CreateNonClientFrameView() OVERRIDE;
   virtual void SetFullscreen(bool fullscreen) OVERRIDE;
   virtual bool IsFullscreen() const OVERRIDE;
   virtual void SetOpacity(unsigned char opacity) OVERRIDE;
@@ -165,11 +167,11 @@ class VIEWS_EXPORT DesktopRootWindowHostWayland :
   // aura:: objects that we own.
   scoped_ptr<aura::client::FocusClient> focus_client_;
   scoped_ptr<views::corewm::CursorManager> cursor_client_;
-  scoped_ptr<DesktopDispatcherClient> dispatcher_client_;
+  scoped_ptr<views::DesktopDispatcherClient> dispatcher_client_;
   scoped_ptr<aura::client::ScreenPositionClient> position_client_;
 
   gfx::AcceleratedWidget window_;
-  internal::NativeWidgetDelegate* native_widget_delegate_;
+  views::internal::NativeWidgetDelegate* native_widget_delegate_;
 
   // Is the window mapped to the screen?
   bool window_mapped_;
@@ -179,7 +181,7 @@ class VIEWS_EXPORT DesktopRootWindowHostWayland :
   aura::RootWindowHostDelegate* root_window_host_delegate_;
   aura::Window* content_window_;
 
-  DesktopNativeWidgetAura* desktop_native_widget_aura_;
+  views::DesktopNativeWidgetAura* desktop_native_widget_aura_;
 
   // The current root window host that has capture. While X11 has something
   // like Windows SetCapture()/ReleaseCapture(), it is entirely implicit and
@@ -191,6 +193,6 @@ class VIEWS_EXPORT DesktopRootWindowHostWayland :
   DISALLOW_COPY_AND_ASSIGN(DesktopRootWindowHostWayland);
 };
 
-}  // namespace views
+}  // namespace ozonewayland
 
 #endif  // DESKTOP_ROOT_WINDOW_HOST_WAYLAND_H_

--- a/impl/desktop_screen_wayland.cc
+++ b/impl/desktop_screen_wayland.cc
@@ -7,6 +7,8 @@
 #include <stdio.h>
 #include "ui/base/ozone/surface_factory_ozone.h"
 
+namespace ozonewayland {
+
 namespace {
 
 gfx::Size GetPrimaryDisplaySize() {
@@ -79,4 +81,6 @@ void DesktopScreenWayland::AddObserver(gfx::DisplayObserver* observer) {
 }
 
 void DesktopScreenWayland::RemoveObserver(gfx::DisplayObserver* observer) {
+}
+
 }

--- a/impl/desktop_screen_wayland.h
+++ b/impl/desktop_screen_wayland.h
@@ -7,6 +7,8 @@
 
 #include "ui/gfx/screen.h"
 
+namespace ozonewayland {
+
 class DesktopScreenWayland : public gfx::Screen {
  public:
   DesktopScreenWayland();
@@ -33,5 +35,7 @@ class DesktopScreenWayland : public gfx::Screen {
 
   DISALLOW_COPY_AND_ASSIGN(DesktopScreenWayland);
 };
+
+}
 
 #endif  // DESKTOP_SCREEN_WAYLAND_H__

--- a/impl/event_factory_wayland.cc
+++ b/impl/event_factory_wayland.cc
@@ -10,7 +10,7 @@
 #include "base/lazy_instance.h"
 #include "base/memory/scoped_ptr.h"
 
-namespace ui {
+namespace ozonewayland {
 
 // Implementation.
 static base::LazyInstance<scoped_ptr<EventFactoryWayland> > impl_ =
@@ -31,7 +31,7 @@ EventFactoryWayland::EventFactoryWayland()
   CHECK(success);
   DCHECK(base::MessageLoop::current());
   base::MessageLoop::current()->AddTaskObserver(this);
-  dispatcher_ = ui::WaylandDispatcher::GetInstance();
+  dispatcher_ = WaylandDispatcher::GetInstance();
 }
 
 EventFactoryWayland::~EventFactoryWayland() {
@@ -83,4 +83,4 @@ void EventFactoryWayland::WillDestroyCurrentMessageLoop()
   base::MessageLoop::current()->RemoveTaskObserver(this);
 }
 
-}  // namespace ui
+}  // namespace ozonewayland

--- a/impl/event_factory_wayland.h
+++ b/impl/event_factory_wayland.h
@@ -9,7 +9,7 @@
 #include "base/message_loop/message_loop.h"
 #include "base/message_loop/message_pump_libevent.h"
 
-namespace ui {
+namespace ozonewayland {
 
 class WaylandDispatcher;
 
@@ -41,6 +41,6 @@ class EventFactoryWayland : public base::MessageLoop::TaskObserver,
   WaylandDispatcher* dispatcher_;
 };
 
-}  // namespace ui
+}  // namespace ozonewayland
 
 #endif  // OZONE_WAYLAND_EVENT_FACTORY_H_

--- a/impl/ipc/child_process_observer.cc
+++ b/impl/ipc/child_process_observer.cc
@@ -6,7 +6,7 @@
 #include "ozone/impl/ozone_display.h"
 #include "content/public/common/process_type.h"
 
-namespace OzoneWayland {
+namespace ozonewayland {
 
 OzoneProcessObserver::OzoneProcessObserver(OzoneDisplay* observer)
     : observer_(observer)
@@ -42,4 +42,4 @@ void OzoneProcessObserver::WillDestroyCurrentMessageLoop()
   BrowserChildProcessObserver::Remove(this);
 }
 
-}  // namespace content
+}  // namespace ozonewayland

--- a/impl/ipc/child_process_observer.h
+++ b/impl/ipc/child_process_observer.h
@@ -8,7 +8,7 @@
 #include "content/public/browser/browser_child_process_observer.h"
 #include "content/public/browser/child_process_data.h"
 
-namespace OzoneWayland {
+namespace ozonewayland {
 
 class OzoneDisplay;
 
@@ -37,6 +37,6 @@ class OzoneProcessObserver : public content::BrowserChildProcessObserver {
   DISALLOW_COPY_AND_ASSIGN(OzoneProcessObserver);
 };
 
-}  // namespace OzoneWayland
+}  // namespace ozonewayland
 
 #endif  // OZONE_WAYLAND_CHILD_PROCESS_OBSERVER

--- a/impl/ipc/display_channel.cc
+++ b/impl/ipc/display_channel.cc
@@ -4,7 +4,7 @@
 
 #include "ozone/impl/ipc/display_channel.h"
 
-#include "ozone/wayland/dispatcher.cc"
+#include "ozone/wayland/dispatcher.h"
 
 #include "ozone/impl/ozone_display.h"
 
@@ -13,12 +13,15 @@
 #include "ipc/ipc_sync_channel.h"
 #include "ipc/ipc_channel_handle.h"
 
-namespace OzoneWayland {
+namespace ozonewayland {
 
-content::ChildThread* GetProcessMainThread()
-{
+namespace {
+
+content::ChildThread* GetProcessMainThread() {
   content::ChildProcess* process = content::ChildProcess::current();
   return process ? process->main_thread() : NULL;
+}
+
 }
 
 OzoneDisplayChannel::OzoneDisplayChannel(unsigned fd)
@@ -74,4 +77,4 @@ void OzoneDisplayChannel::Register()
   }
 }
 
-} // namespace OzoneWayland
+} // namespace ozonewayland

--- a/impl/ipc/display_channel.h
+++ b/impl/ipc/display_channel.h
@@ -8,7 +8,7 @@
 #include "ozone/wayland/dispatcher.h"
 #include "ipc/ipc_listener.h"
 
-namespace OzoneWayland {
+namespace ozonewayland {
 
 // OzoneDisplayChannel is responsible for listening to any messages sent by it's
 // host counterpart in BrowserProcess. There will be always only one

--- a/impl/ipc/display_channel_host.cc
+++ b/impl/ipc/display_channel_host.cc
@@ -7,14 +7,14 @@
 #include "ozone/impl/ozone_display.h"
 #include "base/bind.h"
 
-namespace OzoneWayland {
+namespace ozonewayland {
 
 OzoneDisplayChannelHost::OzoneDisplayChannelHost()
     : process_id_(0),
       host_id_(0),
       router_id_(0)
 {
-  dispatcher_ = ui::WaylandDispatcher::GetInstance();
+  dispatcher_ = WaylandDispatcher::GetInstance();
 }
 
 OzoneDisplayChannelHost::~OzoneDisplayChannelHost()
@@ -122,4 +122,4 @@ void OzoneDisplayChannelHost::OnOutputSizeChanged(unsigned width,
   OzoneDisplay::GetInstance()->OnOutputSizeChanged(width, height);
 }
 
-}  // namespace OzoneWayland
+}  // namespace ozonewayland

--- a/impl/ipc/display_channel_host.h
+++ b/impl/ipc/display_channel_host.h
@@ -9,7 +9,7 @@
 #include "content/public/browser/browser_message_filter.h"
 #include "content/browser/gpu/gpu_process_host.h"
 
-namespace OzoneWayland {
+namespace ozonewayland {
 
 // OzoneDisplayChannelHost is responsible for listening to any relevant messages
 // sent from gpu process(i.e dispatcher and OzoneDisplayChannel). There will
@@ -39,13 +39,13 @@ class OzoneDisplayChannelHost : public content::BrowserMessageFilter {
   bool UpdateConnection(int process_id);
 
  private:
-  ui::WaylandDispatcher* dispatcher_;
+  WaylandDispatcher* dispatcher_;
   unsigned process_id_;
   unsigned host_id_;
   unsigned router_id_;
   DISALLOW_COPY_AND_ASSIGN(OzoneDisplayChannelHost);
 };
 
-}  // namespace OzoneWayland
+}  // namespace ozonewayland
 
 #endif  // OZONE_WAYLAND_DISPLAY_CHANNEL_HOST_H_

--- a/impl/ozone_display.cc
+++ b/impl/ozone_display.cc
@@ -20,7 +20,7 @@
 #include "base/command_line.h"
 #include "content/public/common/content_switches.h"
 
-namespace OzoneWayland {
+namespace ozonewayland {
 
 OzoneDisplay* OzoneDisplay::instance_ = NULL;
 
@@ -60,22 +60,22 @@ ui::SurfaceFactoryOzone::HardwareState OzoneDisplay::InitializeHardware()
  bool browserProcess = (launch_type_ & MultiProcess) && (process_type_ & Browser);
 
  if (singleProcess || gpuProcess) {
-   display_ = new ui::WaylandDisplay();
+   display_ = new WaylandDisplay();
    initialized_state_ = display_->display() ? ui::SurfaceFactoryOzone::INITIALIZED
                                             : ui::SurfaceFactoryOzone::FAILED;
  }
 
  if (singleProcess || browserProcess)
-   dispatcher_ = new ui::WaylandDispatcher();
+   dispatcher_ = new WaylandDispatcher();
 
  if (singleProcess) {
-   e_factory_ = new ui::EventFactoryWayland();
-   ui::EventFactoryWayland::SetInstance(e_factory_);
+   e_factory_ = new EventFactoryWayland();
+   EventFactoryWayland::SetInstance(e_factory_);
  } else if (gpuProcess) {
    int fd = wl_display_get_fd(display_->display());
-   dispatcher_ = new ui::WaylandDispatcher(fd);
+   dispatcher_ = new WaylandDispatcher(fd);
    channel_ = new OzoneDisplayChannel(fd);
-   dispatcher_->PostTask(ui::WaylandDispatcher::Poll);
+   dispatcher_->PostTask(WaylandDispatcher::Poll);
  } else if (browserProcess) {
    child_process_observer_ = new OzoneProcessObserver(this);
    initialized_state_ = ui::SurfaceFactoryOzone::INITIALIZED;
@@ -151,8 +151,8 @@ intptr_t OzoneDisplay::GetNativeDisplay()
 gfx::AcceleratedWidget OzoneDisplay::GetAcceleratedWidget()
 {
   if (!root_window_)
-    root_window_ = new ui::WaylandWindow(display_ ? ui::WaylandWindow::TOPLEVEL
-                                                  : ui::WaylandWindow::None);
+    root_window_ = new WaylandWindow(display_ ? WaylandWindow::TOPLEVEL
+                                              : WaylandWindow::None);
 
   return (gfx::AcceleratedWidget)root_window_->Handle();
 }
@@ -161,7 +161,7 @@ gfx::AcceleratedWidget OzoneDisplay::RealizeAcceleratedWidget(
     gfx::AcceleratedWidget w) {
   // TODO(kalyan): Map w to window.
   if (!root_window_)
-    root_window_ = new ui::WaylandWindow();
+    root_window_ = new WaylandWindow();
 
   root_window_->RealizeAcceleratedWidget();
 
@@ -211,7 +211,7 @@ gfx::Screen* OzoneDisplay::CreateDesktopScreen() {
 }
 
 bool OzoneDisplay::LoadEGLGLES2Bindings() {
-  return gfx::InitializeGLBindings();
+  return InitializeGLBindings();
 }
 
 void OzoneDisplay::EstablishChannel(unsigned id)
@@ -246,7 +246,7 @@ void OzoneDisplay::OnChannelHostDestroyed()
   host_ = NULL;
 }
 
-void OzoneDisplay::OnOutputSizeChanged(ui::WaylandScreen* screen, int width,
+void OzoneDisplay::OnOutputSizeChanged(WaylandScreen* screen, int width,
                                        int height)
 {
   if (screen == display_->PrimaryScreen()) {
@@ -312,4 +312,4 @@ void OzoneDisplay::ValidateLaunchType()
   }
 }
 
-}  // namespace OzoneWayland
+}  // namespace ozonewayland

--- a/impl/ozone_display.h
+++ b/impl/ozone_display.h
@@ -9,19 +9,16 @@
 #include "base/message_loop/message_loop.h"
 #include "ui/base/ozone/surface_factory_ozone.h"
 
-namespace ui {
+namespace ozonewayland {
+
 class EventFactoryWayland;
+class OzoneProcessObserver;
+class OzoneDisplayChannel;
+class OzoneDisplayChannelHost;
 class WaylandDisplay;
 class WaylandWindow;
 class WaylandDispatcher;
 class WaylandScreen;
-}
-
-namespace OzoneWayland {
-
-class OzoneProcessObserver;
-class OzoneDisplayChannel;
-class OzoneDisplayChannelHost;
 
 class OzoneDisplay : public ui::SurfaceFactoryOzone,
                      public base::MessageLoop::DestructionObserver {
@@ -82,7 +79,7 @@ class OzoneDisplay : public ui::SurfaceFactoryOzone,
   void OnChannelEstablished(unsigned id);
   void OnChannelClosed(unsigned id);
   void OnChannelHostDestroyed();
-  void OnOutputSizeChanged(ui::WaylandScreen* screen, int width, int height);
+  void OnOutputSizeChanged(WaylandScreen* screen, int width, int height);
   void OnOutputSizeChanged(unsigned width, unsigned height);
 
   void Terminate();
@@ -94,23 +91,23 @@ class OzoneDisplay : public ui::SurfaceFactoryOzone,
   ui::SurfaceFactoryOzone::HardwareState initialized_state_;
   bool initialized_ :1;
 
-  ui::WaylandDispatcher* dispatcher_;
-  ui::WaylandDisplay* display_;
-  ui::WaylandWindow* root_window_;
+  WaylandDispatcher* dispatcher_;
+  WaylandDisplay* display_;
+  WaylandWindow* root_window_;
   OzoneProcessObserver* child_process_observer_;
   OzoneDisplayChannel* channel_;
   OzoneDisplayChannelHost* host_;
-  ui::EventFactoryWayland* e_factory_;
+  EventFactoryWayland* e_factory_;
   char* spec_;
   static OzoneDisplay* instance_;
 
   friend class OzoneProcessObserver;
   friend class OzoneDisplayChannelHost;
   friend class OzoneDisplayChannel;
-  friend class ui::WaylandScreen;
+  friend class WaylandScreen;
   DISALLOW_COPY_AND_ASSIGN(OzoneDisplay);
 };
 
-}  // namespace OzoneWayland
+}  // namespace ozonewayland
 
 #endif  // OZONE_WAYLAND_OZONE_DISPLAY_H_

--- a/patches/0002-Set-Wayland-as-the-implementation-for-SurfaceFactory.patch
+++ b/patches/0002-Set-Wayland-as-the-implementation-for-SurfaceFactory.patch
@@ -1,6 +1,6 @@
-From 8069782184289973570ff69dd61dc1f6384db5f7 Mon Sep 17 00:00:00 2001
+From b3a32216e6f44f5b1ae4523cf8d471ae516b52a0 Mon Sep 17 00:00:00 2001
 From: Kondapally Kalyan <kalyan.kondapally@intel.com>
-Date: Wed, 11 Sep 2013 19:58:53 +0300
+Date: Thu, 12 Sep 2013 12:11:23 +0300
 Subject: [PATCH] Set Wayland as the implementation for SurfaceFactoryOzone
 
 The fundamental problem to be solved here is to find a way to set downstream
@@ -38,7 +38,7 @@ index f04e4a9..673dfbc 100644
            ['(OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="solaris") and chromeos==0', {
              'desktop_linux%': 1,
 diff --git a/content/shell/app/shell_main_delegate.cc b/content/shell/app/shell_main_delegate.cc
-index 8e60a32..754e867 100644
+index 8e60a32..5d9799a 100644
 --- a/content/shell/app/shell_main_delegate.cc
 +++ b/content/shell/app/shell_main_delegate.cc
 @@ -24,6 +24,9 @@
@@ -70,9 +70,9 @@ index 8e60a32..754e867 100644
    InitializeResourceBundle();
 +
 +  /* TODO: Implementation specific. Has to go away */
-+  ui::SurfaceFactoryOzone *o_factory = new OzoneWayland::OzoneDisplay();
++  ui::SurfaceFactoryOzone *o_factory = new ozonewayland::OzoneDisplay();
 +  ui::SurfaceFactoryOzone::SetInstance(o_factory);
-+  views::DesktopFactoryOzone *d_factory = new views::DesktopFactoryWayland();
++  views::DesktopFactoryOzone *d_factory = new ozonewayland::DesktopFactoryWayland();
 +  views::DesktopFactoryOzone::SetInstance(d_factory);
  }
  
@@ -111,7 +111,7 @@ index b2fd97e..b38cf15 100644
  
  int DemoMain() {
 +  /* TODO: Implementation specific. Has to go away */
-+  ui::SurfaceFactoryOzone *o_factory = new OzoneWayland::OzoneDisplay();
++  ui::SurfaceFactoryOzone *o_factory = new ozonewayland::OzoneDisplay();
 +  ui::SurfaceFactoryOzone::SetInstance(o_factory);
 +
    // Create the message-loop here before creating the root window.

--- a/wayland/cursor.cc
+++ b/wayland/cursor.cc
@@ -5,7 +5,7 @@
 #include "ozone/wayland/cursor.h"
 #include "ozone/wayland/surface.h"
 
-namespace ui {
+namespace ozonewayland {
 
 class WaylandCursorData {
 public:
@@ -138,5 +138,5 @@ void WaylandCursor::Clear()
   WaylandCursorData::GetInstance()->Clear();
 }
 
-}  // namespace ui
+}  // namespace ozonewayland
 

--- a/wayland/cursor.h
+++ b/wayland/cursor.h
@@ -8,7 +8,7 @@
 #include "ozone/wayland/input_device.h"
 #include <wayland-cursor.h>
 
-namespace ui {
+namespace ozonewayland {
 class WaylandCursorData;
 class WaylandSurface;
 class WaylandDisplay;
@@ -52,6 +52,6 @@ private:
   DISALLOW_COPY_AND_ASSIGN(WaylandCursor);
 };
 
-}  // namespace ui
+}  // namespace ozonewayland
 
 #endif  // OZONE_WAYLAND_DISPLAY_H_

--- a/wayland/dispatcher.cc
+++ b/wayland/dispatcher.cc
@@ -18,7 +18,19 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 
-namespace ui {
+namespace {
+
+content::ChildThread* GetProcessMainThread()
+{
+  content::ChildProcess* process = content::ChildProcess::current();
+  DCHECK(process);
+  DCHECK(process->main_thread());
+  return process ? process->main_thread() : NULL;
+}
+
+}
+
+namespace ozonewayland {
 WaylandDispatcher* WaylandDispatcher::instance_ = NULL;
 
 // os-compatibility
@@ -63,15 +75,6 @@ int osEpollCreateCloExec(void)
 }
 
 } // os-compatibility
-
-
-content::ChildThread* GetProcessMainThread()
-{
-  content::ChildProcess* process = content::ChildProcess::current();
-  DCHECK(process);
-  DCHECK(process->main_thread());
-  return process ? process->main_thread() : NULL;
-}
 
 WaylandDispatcher::WaylandDispatcher(int fd)
     : Thread("WaylandDispatcher"),
@@ -277,9 +280,11 @@ void WaylandDispatcher::MotionNotify(float x, float y)
     PostTaskOnMainLoop(FROM_HERE, base::Bind(
                         &WaylandDispatcher::SendMotionNotify, x, y));
   } else {
-    scoped_ptr<MouseEvent> mouseev(new MouseEvent(ui::ET_MOUSE_MOVED,
-                                                  gfx::Point(x, y),
-                                                  gfx::Point(x, y), 0));
+    scoped_ptr<ui::MouseEvent> mouseev(
+       new ui::MouseEvent(ui::ET_MOUSE_MOVED,
+                          gfx::Point(x, y),
+                          gfx::Point(x, y),
+                          0));
 
     PostTaskOnMainLoop(FROM_HERE, base::Bind(
                         &WaylandDispatcher::DispatchEventHelper, base::Passed(
@@ -295,14 +300,17 @@ void WaylandDispatcher::ButtonNotify(int state, int flags, float x, float y)
     PostTaskOnMainLoop(FROM_HERE, base::Bind(&WaylandDispatcher::SendButtonNotify,
                                              state, flags, x, y));
   } else {
-    EventType type;
+    ui::EventType type;
     if (state == 1)
       type = ui::ET_MOUSE_PRESSED;
     else
       type = ui::ET_MOUSE_RELEASED;
 
-    scoped_ptr<MouseEvent> mouseev(new MouseEvent(type, gfx::Point(x, y),
-                                                  gfx::Point(x, y), flags));
+    scoped_ptr<ui::MouseEvent> mouseev(
+       new ui::MouseEvent(type,
+                          gfx::Point(x, y),
+                          gfx::Point(x, y),
+                          flags));
 
     PostTaskOnMainLoop(FROM_HERE, base::Bind(
                         &WaylandDispatcher::DispatchEventHelper, base::Passed(
@@ -319,9 +327,17 @@ void WaylandDispatcher::AxisNotify(float x, float y, float xoffset, float yoffse
     PostTaskOnMainLoop(FROM_HERE, base::Bind(&WaylandDispatcher::SendAxisNotify,
                                              x, y, xoffset, yoffset));
   } else {
-    MouseEvent mouseev(ui::ET_MOUSEWHEEL, gfx::Point(x,y), gfx::Point(x,y), 0);
-    scoped_ptr<MouseWheelEvent> wheelev(new MouseWheelEvent(mouseev, xoffset,
-                                                            yoffset));
+    ui::MouseEvent mouseev(
+       ui::ET_MOUSEWHEEL,
+       gfx::Point(x,y),
+       gfx::Point(x,y),
+       0);
+
+    scoped_ptr<ui::MouseWheelEvent> wheelev(
+       new ui::MouseWheelEvent(mouseev,
+                               xoffset,
+                               yoffset));
+
     PostTaskOnMainLoop(FROM_HERE, base::Bind(
                         &WaylandDispatcher::DispatchEventHelper, base::Passed(
                                               wheelev.PassAs<ui::Event>())));
@@ -336,9 +352,11 @@ void WaylandDispatcher::PointerEnter(float x, float y)
     PostTaskOnMainLoop(FROM_HERE, base::Bind(&WaylandDispatcher::SendPointerEnter,
                                              x, y));
   } else {
-    scoped_ptr<MouseEvent> mouseev(new MouseEvent(ui::ET_MOUSE_ENTERED,
-                                                  gfx::Point(x, y),
-                                                  gfx::Point(x, y), 0));
+    scoped_ptr<ui::MouseEvent> mouseev(
+       new ui::MouseEvent(ui::ET_MOUSE_ENTERED,
+                          gfx::Point(x, y),
+                          gfx::Point(x, y),
+                          0));
 
     PostTaskOnMainLoop(FROM_HERE, base::Bind(
                         &WaylandDispatcher::DispatchEventHelper, base::Passed(
@@ -354,9 +372,12 @@ void WaylandDispatcher::PointerLeave(float x, float y)
     PostTaskOnMainLoop(FROM_HERE, base::Bind(&WaylandDispatcher::SendPointerLeave,
                                              x, y));
   } else {
-    scoped_ptr<MouseEvent> mouseev(new MouseEvent(ui::ET_MOUSE_EXITED,
-                                                  gfx::Point(x, y),
-                                                  gfx::Point(x, y),0));
+    scoped_ptr<ui::MouseEvent> mouseev(
+       new ui::MouseEvent(ui::ET_MOUSE_EXITED,
+                          gfx::Point(x, y),
+                          gfx::Point(x, y),
+                          0));
+
     PostTaskOnMainLoop(FROM_HERE, base::Bind(
                         &WaylandDispatcher::DispatchEventHelper, base::Passed(
                                               mouseev.PassAs<ui::Event>())));
@@ -372,14 +393,18 @@ void WaylandDispatcher::KeyNotify(unsigned state, unsigned code,
     PostTaskOnMainLoop(FROM_HERE, base::Bind(&WaylandDispatcher::SendKeyNotify,
                                              state, code, modifiers));
   } else {
-    EventType type;
+    ui::EventType type;
     if (state)
-      type = ET_KEY_PRESSED;
+      type = ui::ET_KEY_PRESSED;
     else
-      type = ET_KEY_RELEASED;
+      type = ui::ET_KEY_RELEASED;
 
-    scoped_ptr<KeyEvent> keyev(new KeyEvent(type, ui::KeyboardCodeFromXKeysym(code),
-                                            modifiers, true));
+    scoped_ptr<ui::KeyEvent> keyev(
+       new ui::KeyEvent(type,
+                        KeyboardCodeFromXKeysym(code),
+                        0,
+                        true));
+
     PostTaskOnMainLoop(FROM_HERE, base::Bind(
                         &WaylandDispatcher::DispatchEventHelper, base::Passed(
                                               keyev.PassAs<ui::Event>())));
@@ -395,4 +420,4 @@ void WaylandDispatcher::OutputSizeChanged(unsigned width, unsigned height)
                       &WaylandDispatcher::SendOutputSizeChanged, width, height));
 }
 
-}  // namespace ui
+}  // namespace ozonewayland

--- a/wayland/dispatcher.h
+++ b/wayland/dispatcher.h
@@ -11,13 +11,10 @@
 #include "ui/base/events/event.h"
 #include "ozone/wayland/display.h"
 
-namespace OzoneWayland {
+namespace ozonewayland {
+class EventFactoryWayland;
 class OzoneDisplay;
 class OzoneDisplayChannel;
-}
-
-namespace ui {
-class EventFactoryWayland;
 
 // WaylandDispatcher class is used by OzoneDisplay for reading pending events
 // coming from Wayland compositor and flush requests back. WaylandDispatcher is
@@ -79,11 +76,11 @@ class WaylandDispatcher : public base::Thread {
   int display_fd_;
   static WaylandDispatcher* instance_;
   friend class EventFactoryWayland;
-  friend class OzoneWayland::OzoneDisplay;
-  friend class OzoneWayland::OzoneDisplayChannel;
+  friend class OzoneDisplay;
+  friend class OzoneDisplayChannel;
   DISALLOW_COPY_AND_ASSIGN(WaylandDispatcher);
 };
 
-}  // namespace ui
+}  // namespace ozonewayland
 
 #endif  // OZONE_WAYLAND_DISPATCHER_H_

--- a/wayland/display.cc
+++ b/wayland/display.cc
@@ -10,7 +10,7 @@
 #include "ozone/wayland/window.h"
 #include "ozone/wayland/cursor.h"
 
-namespace ui {
+namespace ozonewayland {
 WaylandDisplay* WaylandDisplay::instance_ = NULL;
 
 WaylandDisplay::WaylandDisplay() :compositor_(NULL),
@@ -111,4 +111,4 @@ void WaylandDisplay::DisplayHandleGlobal(void *data,
   }
 }
 
-}  // namespace ui
+}  // namespace ozonewayland

--- a/wayland/display.h
+++ b/wayland/display.h
@@ -15,14 +15,11 @@
 #include <list>
 #include <wayland-client.h>
 
-namespace OzoneWayland {
-class OzoneDisplay;
-}
-
-namespace ui {
+namespace ozonewayland {
 
 class WaylandInputDevice;
 class WaylandScreen;
+class OzoneDisplay;
 
 // WaylandDisplay is a wrapper around wl_display. Once we get a valid
 // wl_display, the Wayland server will send different events to register
@@ -69,10 +66,10 @@ class WaylandDisplay {
   std::list<WaylandInputDevice*> input_list_;
   static WaylandDisplay* instance_;
 
-  friend class OzoneWayland::OzoneDisplay;
+  friend class OzoneDisplay;
   DISALLOW_COPY_AND_ASSIGN(WaylandDisplay);
 };
 
-}  // namespace ui
+}  // namespace ozonewayland
 
 #endif  // OZONE_WAYLAND_DISPLAY_H_

--- a/wayland/egl/egl_window.cc
+++ b/wayland/egl/egl_window.cc
@@ -8,7 +8,7 @@
 #include "ozone/wayland/surface.h"
 #include <wayland-egl.h>
 
-namespace ui {
+namespace ozonewayland {
 
 EGLWindow::EGLWindow(struct wl_surface* surface, int32_t width, int32_t height)
     : window_(NULL)
@@ -41,4 +41,4 @@ bool EGLWindow::Resize(WaylandSurface* surface, int32_t width, int32_t height)
     return true;
 }
 
-}  // namespace ui
+}  // namespace ozonewayland

--- a/wayland/egl/egl_window.h
+++ b/wayland/egl/egl_window.h
@@ -10,7 +10,7 @@
 
 struct wl_egl_window;
 
-namespace ui {
+namespace ozonewayland {
 
 class WaylandSurface;
 class EGLWindow {
@@ -26,6 +26,6 @@ class EGLWindow {
   DISALLOW_COPY_AND_ASSIGN(EGLWindow);
 };
 
-}  // namespace ui
+}  // namespace ozonewayland
 
 #endif  // OZONE_WAYLAND_EGL_WINDOW_H_

--- a/wayland/egl/loader.cc
+++ b/wayland/egl/loader.cc
@@ -10,7 +10,7 @@
 #include "ui/gl/gl_implementation.h"
 #include "ui/gl/gl_switches.h"
 
-namespace gfx {
+namespace ozonewayland {
 
 namespace {
 
@@ -42,8 +42,8 @@ bool InitializeGLBindings() {
     return false;
   }
 
-  GLGetProcAddressProc get_proc_address =
-      reinterpret_cast<GLGetProcAddressProc>(
+  gfx::GLGetProcAddressProc get_proc_address =
+      reinterpret_cast<gfx::GLGetProcAddressProc>(
           base::GetFunctionPointerFromNativeLibrary(
               egl_library, "eglGetProcAddress"));
   if (!get_proc_address) {
@@ -53,11 +53,11 @@ bool InitializeGLBindings() {
     return false;
   }
 
-  SetGLGetProcAddressProc(get_proc_address);
-  AddGLNativeLibrary(egl_library);
-  AddGLNativeLibrary(gles_library);
+  gfx::SetGLGetProcAddressProc(get_proc_address);
+  gfx::AddGLNativeLibrary(egl_library);
+  gfx::AddGLNativeLibrary(gles_library);
 
   return true;
 }
 
-}  // namespace gfx
+}  // namespace ozonewayland

--- a/wayland/egl/loader.h
+++ b/wayland/egl/loader.h
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 
-namespace gfx {
+namespace ozonewayland {
 
 bool InitializeGLBindings();
 

--- a/wayland/global.h
+++ b/wayland/global.h
@@ -5,7 +5,7 @@
 #ifndef OZONE_WAYLAND_GLOBAL_H_
 #define OZONE_WAYLAND_GLOBAL_H_
 
-namespace ui {
+namespace ozonewayland {
 
 #define MOD_SHIFT_MASK		0x01
 #define MOD_ALT_MASK		0x02
@@ -35,7 +35,7 @@ enum BoundsChangeType
   kBoundsChange_Resizes,
 };
 
-}  // namespace ui
+}  // namespace ozonewayland
 
 #endif  // OZONE_WAYLAND_DISPLAY_H_
 

--- a/wayland/input_device.cc
+++ b/wayland/input_device.cc
@@ -8,7 +8,7 @@
 #include "ozone/wayland/keyboard.h"
 #include "ozone/wayland/pointer.h"
 
-namespace ui {
+namespace ozonewayland {
 
 WaylandInputDevice::WaylandInputDevice(WaylandDisplay* display, uint32_t id)
   :input_keyboard_(NULL),
@@ -73,4 +73,4 @@ InputMethod* WaylandInputDevice::GetInputMethod() const
   input_method_filter_->GetInputMethod();
 }
 
-}  // namespace ui
+}  // namespace ozonewayland

--- a/wayland/input_device.h
+++ b/wayland/input_device.h
@@ -7,7 +7,7 @@
 
 #include "ozone/wayland/display.h"
 
-namespace ui {
+namespace ozonewayland {
 
 class Event;
 class WaylandKeyboard;
@@ -39,6 +39,6 @@ class WaylandInputDevice {
   DISALLOW_COPY_AND_ASSIGN(WaylandInputDevice);
 };
 
-}  // namespace ui
+}  // namespace ozonewayland
 
 #endif  // OZONE_WAYLAND_INPUT_DEVICE_H_

--- a/wayland/input_method_event_filter.cc
+++ b/wayland/input_method_event_filter.cc
@@ -7,7 +7,7 @@
 #include "ui/base/ime/input_method.h"
 #include "ui/base/ime/input_method_factory.h"
 
-namespace ui {
+namespace ozonewayland {
 
 ////////////////////////////////////////////////////////////////////////////////
 // InputMethodEventFilter, public:
@@ -38,4 +38,4 @@ bool WaylandInputMethodEventFilter::DispatchFabricatedKeyEventPostIME(
 {
 }
 
-}  // namespace ui
+}  // namespace ozonewayland

--- a/wayland/input_method_event_filter.h
+++ b/wayland/input_method_event_filter.h
@@ -12,7 +12,9 @@
 
 namespace ui {
 class InputMethod;
+}
 
+namespace ozonewayland {
 // An event filter that forwards a KeyEvent to a system IME, and dispatches a
 // TranslatedKeyEvent to the root window as needed.
 class WaylandInputMethodEventFilter
@@ -21,7 +23,7 @@ class WaylandInputMethodEventFilter
   WaylandInputMethodEventFilter();
   virtual ~WaylandInputMethodEventFilter();
 
-  InputMethod* GetInputMethod() const { return input_method_.get(); }
+  ui::InputMethod* GetInputMethod() const { return input_method_.get(); }
 
  private:
   // Overridden from ui::internal::InputMethodDelegate.
@@ -35,6 +37,6 @@ class WaylandInputMethodEventFilter
   DISALLOW_COPY_AND_ASSIGN(WaylandInputMethodEventFilter);
 };
 
-}  // namespace ui
+}  // namespace ozonewayland
 
 #endif  // OZONE_WAYLAND_INPUT_METHOD_EVENT_FILTER_

--- a/wayland/kbd_conversion.cc
+++ b/wayland/kbd_conversion.cc
@@ -11,149 +11,149 @@
 #include "base/logging.h"
 #include "base/strings/stringprintf.h"
 
-namespace ui {
+namespace ozonewayland {
 
-KeyboardCode KeyboardCodeFromXKeysym(unsigned int keysym) {
+ui::KeyboardCode KeyboardCodeFromXKeysym(unsigned int keysym) {
   switch (keysym) {
     case XKB_KEY_BackSpace:
-      return VKEY_BACK;
+      return ui::VKEY_BACK;
     case XKB_KEY_Delete:
     case XKB_KEY_KP_Delete:
-      return VKEY_DELETE;
+      return ui::VKEY_DELETE;
     case XKB_KEY_Tab:
     case XKB_KEY_KP_Tab:
     case XKB_KEY_ISO_Left_Tab:
-      return VKEY_TAB;
+      return ui::VKEY_TAB;
     case XKB_KEY_Linefeed:
     case XKB_KEY_Return:
     case XKB_KEY_KP_Enter:
     case XKB_KEY_ISO_Enter:
-      return VKEY_RETURN;
+      return ui::VKEY_RETURN;
     case XKB_KEY_Clear:
     case XKB_KEY_KP_Begin:  // NumPad 5 without Num Lock, for crosbug.com/29169.
-      return VKEY_CLEAR;
+      return ui::VKEY_CLEAR;
     case XKB_KEY_KP_Space:
     case XKB_KEY_space:
-      return VKEY_SPACE;
+      return ui::VKEY_SPACE;
     case XKB_KEY_Home:
     case XKB_KEY_KP_Home:
-      return VKEY_HOME;
+      return ui::VKEY_HOME;
     case XKB_KEY_End:
     case XKB_KEY_KP_End:
-      return VKEY_END;
+      return ui::VKEY_END;
     case XKB_KEY_Page_Up:
     case XKB_KEY_KP_Page_Up:  // aka XKB_KEY_KP_Prior
-      return VKEY_PRIOR;
+      return ui::VKEY_PRIOR;
     case XKB_KEY_Page_Down:
     case XKB_KEY_KP_Page_Down:  // aka XKB_KEY_KP_Next
-      return VKEY_NEXT;
+      return ui::VKEY_NEXT;
     case XKB_KEY_Left:
     case XKB_KEY_KP_Left:
-      return VKEY_LEFT;
+      return ui::VKEY_LEFT;
     case XKB_KEY_Right:
     case XKB_KEY_KP_Right:
-      return VKEY_RIGHT;
+      return ui::VKEY_RIGHT;
     case XKB_KEY_Down:
     case XKB_KEY_KP_Down:
-      return VKEY_DOWN;
+      return ui::VKEY_DOWN;
     case XKB_KEY_Up:
     case XKB_KEY_KP_Up:
-      return VKEY_UP;
+      return ui::VKEY_UP;
     case XKB_KEY_Escape:
-      return VKEY_ESCAPE;
+      return ui::VKEY_ESCAPE;
     case XKB_KEY_Kana_Lock:
     case XKB_KEY_Kana_Shift:
-      return VKEY_KANA;
+      return ui::VKEY_KANA;
     case XKB_KEY_Hangul:
-      return VKEY_HANGUL;
+      return ui::VKEY_HANGUL;
     case XKB_KEY_Hangul_Hanja:
-      return VKEY_HANJA;
+      return ui::VKEY_HANJA;
     case XKB_KEY_Kanji:
-      return VKEY_KANJI;
+      return ui::VKEY_KANJI;
     case XKB_KEY_Henkan:
-      return VKEY_CONVERT;
+      return ui::VKEY_CONVERT;
     case XKB_KEY_Muhenkan:
-      return VKEY_NONCONVERT;
+      return ui::VKEY_NONCONVERT;
     case XKB_KEY_Zenkaku_Hankaku:
-      return VKEY_DBE_DBCSCHAR;
+      return ui::VKEY_DBE_DBCSCHAR;
     case XKB_KEY_A:
     case XKB_KEY_a:
-      return VKEY_A;
+      return ui::VKEY_A;
     case XKB_KEY_B:
     case XKB_KEY_b:
-      return VKEY_B;
+      return ui::VKEY_B;
     case XKB_KEY_C:
     case XKB_KEY_c:
-      return VKEY_C;
+      return ui::VKEY_C;
     case XKB_KEY_D:
     case XKB_KEY_d:
-      return VKEY_D;
+      return ui::VKEY_D;
     case XKB_KEY_E:
     case XKB_KEY_e:
-      return VKEY_E;
+      return ui::VKEY_E;
     case XKB_KEY_F:
     case XKB_KEY_f:
-      return VKEY_F;
+      return ui::VKEY_F;
     case XKB_KEY_G:
     case XKB_KEY_g:
-      return VKEY_G;
+      return ui:: VKEY_G;
     case XKB_KEY_H:
     case XKB_KEY_h:
-      return VKEY_H;
+      return ui::VKEY_H;
     case XKB_KEY_I:
     case XKB_KEY_i:
-      return VKEY_I;
+      return ui::VKEY_I;
     case XKB_KEY_J:
     case XKB_KEY_j:
-      return VKEY_J;
+      return ui::VKEY_J;
     case XKB_KEY_K:
     case XKB_KEY_k:
-      return VKEY_K;
+      return ui::VKEY_K;
     case XKB_KEY_L:
     case XKB_KEY_l:
-      return VKEY_L;
+      return ui::VKEY_L;
     case XKB_KEY_M:
     case XKB_KEY_m:
-      return VKEY_M;
+      return ui::VKEY_M;
     case XKB_KEY_N:
     case XKB_KEY_n:
-      return VKEY_N;
+      return ui::VKEY_N;
     case XKB_KEY_O:
     case XKB_KEY_o:
-      return VKEY_O;
+      return ui::VKEY_O;
     case XKB_KEY_P:
     case XKB_KEY_p:
-      return VKEY_P;
+      return ui::VKEY_P;
     case XKB_KEY_Q:
     case XKB_KEY_q:
-      return VKEY_Q;
+      return ui::VKEY_Q;
     case XKB_KEY_R:
     case XKB_KEY_r:
-      return VKEY_R;
+      return ui::VKEY_R;
     case XKB_KEY_S:
     case XKB_KEY_s:
-      return VKEY_S;
+      return ui::VKEY_S;
     case XKB_KEY_T:
     case XKB_KEY_t:
-      return VKEY_T;
+      return ui::VKEY_T;
     case XKB_KEY_U:
     case XKB_KEY_u:
-      return VKEY_U;
+      return ui::VKEY_U;
     case XKB_KEY_V:
     case XKB_KEY_v:
-      return VKEY_V;
+      return ui::VKEY_V;
     case XKB_KEY_W:
     case XKB_KEY_w:
-      return VKEY_W;
+      return ui::VKEY_W;
     case XKB_KEY_X:
     case XKB_KEY_x:
-      return VKEY_X;
+      return ui::VKEY_X;
     case XKB_KEY_Y:
     case XKB_KEY_y:
-      return VKEY_Y;
+      return ui::VKEY_Y;
     case XKB_KEY_Z:
     case XKB_KEY_z:
-      return VKEY_Z;
+      return ui::VKEY_Z;
 
     case XKB_KEY_0:
     case XKB_KEY_1:
@@ -165,28 +165,28 @@ KeyboardCode KeyboardCodeFromXKeysym(unsigned int keysym) {
     case XKB_KEY_7:
     case XKB_KEY_8:
     case XKB_KEY_9:
-      return static_cast<KeyboardCode>(VKEY_0 + (keysym - XKB_KEY_0));
+      return static_cast<ui::KeyboardCode>(ui::VKEY_0 + (keysym - XKB_KEY_0));
 
     case XKB_KEY_parenright:
-      return VKEY_0;
+      return ui::VKEY_0;
     case XKB_KEY_exclam:
-      return VKEY_1;
+      return ui::VKEY_1;
     case XKB_KEY_at:
-      return VKEY_2;
+      return ui::VKEY_2;
     case XKB_KEY_numbersign:
-      return VKEY_3;
+      return ui::VKEY_3;
     case XKB_KEY_dollar:
-      return VKEY_4;
+      return ui::VKEY_4;
     case XKB_KEY_percent:
-      return VKEY_5;
+      return ui::VKEY_5;
     case XKB_KEY_asciicircum:
-      return VKEY_6;
+      return ui::VKEY_6;
     case XKB_KEY_ampersand:
-      return VKEY_7;
+      return ui::VKEY_7;
     case XKB_KEY_asterisk:
-      return VKEY_8;
+      return ui::VKEY_8;
     case XKB_KEY_parenleft:
-      return VKEY_9;
+      return ui::VKEY_9;
 
     case XKB_KEY_KP_0:
     case XKB_KEY_KP_1:
@@ -198,91 +198,91 @@ KeyboardCode KeyboardCodeFromXKeysym(unsigned int keysym) {
     case XKB_KEY_KP_7:
     case XKB_KEY_KP_8:
     case XKB_KEY_KP_9:
-      return static_cast<KeyboardCode>(VKEY_NUMPAD0 + (keysym - XKB_KEY_KP_0));
+      return static_cast<ui::KeyboardCode>(ui::VKEY_NUMPAD0 + (keysym - XKB_KEY_KP_0));
 
     case XKB_KEY_multiply:
     case XKB_KEY_KP_Multiply:
-      return VKEY_MULTIPLY;
+      return ui::VKEY_MULTIPLY;
     case XKB_KEY_KP_Add:
-      return VKEY_ADD;
+      return ui::VKEY_ADD;
     case XKB_KEY_KP_Separator:
-      return VKEY_SEPARATOR;
+      return ui::VKEY_SEPARATOR;
     case XKB_KEY_KP_Subtract:
-      return VKEY_SUBTRACT;
+      return ui::VKEY_SUBTRACT;
     case XKB_KEY_KP_Decimal:
-      return VKEY_DECIMAL;
+      return ui::VKEY_DECIMAL;
     case XKB_KEY_KP_Divide:
-      return VKEY_DIVIDE;
+      return ui::VKEY_DIVIDE;
     case XKB_KEY_KP_Equal:
     case XKB_KEY_equal:
     case XKB_KEY_plus:
-      return VKEY_OEM_PLUS;
+      return ui::VKEY_OEM_PLUS;
     case XKB_KEY_comma:
     case XKB_KEY_less:
-      return VKEY_OEM_COMMA;
+      return ui::VKEY_OEM_COMMA;
     case XKB_KEY_minus:
     case XKB_KEY_underscore:
-      return VKEY_OEM_MINUS;
+      return ui::VKEY_OEM_MINUS;
     case XKB_KEY_greater:
     case XKB_KEY_period:
-      return VKEY_OEM_PERIOD;
+      return ui::VKEY_OEM_PERIOD;
     case XKB_KEY_colon:
     case XKB_KEY_semicolon:
-      return VKEY_OEM_1;
+      return ui::VKEY_OEM_1;
     case XKB_KEY_question:
     case XKB_KEY_slash:
-      return VKEY_OEM_2;
+      return ui::VKEY_OEM_2;
     case XKB_KEY_asciitilde:
     case XKB_KEY_quoteleft:
-      return VKEY_OEM_3;
+      return ui::VKEY_OEM_3;
     case XKB_KEY_bracketleft:
     case XKB_KEY_braceleft:
-      return VKEY_OEM_4;
+      return ui::VKEY_OEM_4;
     case XKB_KEY_backslash:
     case XKB_KEY_bar:
-      return VKEY_OEM_5;
+      return ui::VKEY_OEM_5;
     case XKB_KEY_bracketright:
     case XKB_KEY_braceright:
-      return VKEY_OEM_6;
+      return ui::VKEY_OEM_6;
     case XKB_KEY_quoteright:
     case XKB_KEY_quotedbl:
-      return VKEY_OEM_7;
+      return ui::VKEY_OEM_7;
     case XKB_KEY_Shift_L:
     case XKB_KEY_Shift_R:
-      return VKEY_SHIFT;
+      return ui::VKEY_SHIFT;
     case XKB_KEY_Control_L:
     case XKB_KEY_Control_R:
-      return VKEY_CONTROL;
+      return ui::VKEY_CONTROL;
     case XKB_KEY_Meta_L:
     case XKB_KEY_Meta_R:
     case XKB_KEY_Alt_L:
     case XKB_KEY_Alt_R:
-      return VKEY_MENU;
+      return ui::VKEY_MENU;
     case XKB_KEY_Pause:
-      return VKEY_PAUSE;
+      return ui::VKEY_PAUSE;
     case XKB_KEY_Caps_Lock:
-      return VKEY_CAPITAL;
+      return ui::VKEY_CAPITAL;
     case XKB_KEY_Num_Lock:
-      return VKEY_NUMLOCK;
+      return ui::VKEY_NUMLOCK;
     case XKB_KEY_Scroll_Lock:
-      return VKEY_SCROLL;
+      return ui::VKEY_SCROLL;
     case XKB_KEY_Select:
-      return VKEY_SELECT;
+      return ui::VKEY_SELECT;
     case XKB_KEY_Print:
-      return VKEY_PRINT;
+      return ui::VKEY_PRINT;
     case XKB_KEY_Execute:
-      return VKEY_EXECUTE;
+      return ui::VKEY_EXECUTE;
     case XKB_KEY_Insert:
     case XKB_KEY_KP_Insert:
-      return VKEY_INSERT;
+      return ui::VKEY_INSERT;
     case XKB_KEY_Help:
-      return VKEY_HELP;
+      return ui::VKEY_HELP;
     case XKB_KEY_Super_L:
-      return VKEY_LWIN;
+      return ui::VKEY_LWIN;
     case XKB_KEY_Super_R:
-      return VKEY_RWIN;
+      return ui::VKEY_RWIN;
     case XKB_KEY_Menu:
-      return VKEY_APPS;
+      return ui::VKEY_APPS;
     case XKB_KEY_F1:
     case XKB_KEY_F2:
     case XKB_KEY_F3:
@@ -307,12 +307,12 @@ KeyboardCode KeyboardCodeFromXKeysym(unsigned int keysym) {
     case XKB_KEY_F22:
     case XKB_KEY_F23:
     case XKB_KEY_F24:
-      return static_cast<KeyboardCode>(VKEY_F1 + (keysym - XKB_KEY_F1));
+      return static_cast<ui::KeyboardCode>(ui::VKEY_F1 + (keysym - XKB_KEY_F1));
     case XKB_KEY_KP_F1:
     case XKB_KEY_KP_F2:
     case XKB_KEY_KP_F3:
     case XKB_KEY_KP_F4:
-      return static_cast<KeyboardCode>(VKEY_F1 + (keysym - XKB_KEY_KP_F1));
+      return static_cast<ui::KeyboardCode>(ui::VKEY_F1 + (keysym - XKB_KEY_KP_F1));
 
     case XKB_KEY_guillemotleft:
     case XKB_KEY_guillemotright:
@@ -321,11 +321,11 @@ KeyboardCode KeyboardCodeFromXKeysym(unsigned int keysym) {
     // assigned to ugrave key.
     case XKB_KEY_ugrave:
     case XKB_KEY_Ugrave:
-      return VKEY_OEM_102;  // international backslash key in 102 keyboard.
+      return ui::VKEY_OEM_102;  // international backslash key in 102 keyboard.
   }
   DLOG(WARNING) << "Unknown keysym: " << base::StringPrintf("0x%x", keysym);
-  return VKEY_UNKNOWN;
+  return ui::VKEY_UNKNOWN;
 }
 
-}  // namespace ui
+}  // namespace ozonewayland
 

--- a/wayland/kbd_conversion.h
+++ b/wayland/kbd_conversion.h
@@ -10,10 +10,10 @@
 #include "ui/base/keycodes/keyboard_codes_posix.h"
 #include "ui/base/ui_export.h"
 
-namespace ui {
+namespace ozonewayland {
 
-UI_EXPORT KeyboardCode KeyboardCodeFromXKeysym(unsigned int keysym);
+UI_EXPORT ui::KeyboardCode KeyboardCodeFromXKeysym(unsigned int keysym);
 
-}  // namespace ui
+}  // namespace ozonewayland
 
 #endif  // OZONE_WAYLAND_KBD_CONVERSION_H_

--- a/wayland/keyboard.cc
+++ b/wayland/keyboard.cc
@@ -7,7 +7,7 @@
 #include "ozone/wayland/dispatcher.h"
 #include <sys/mman.h>
 
-namespace ui {
+namespace ozonewayland {
 
 WaylandKeyboard::WaylandKeyboard()
   : input_keyboard_(NULL),
@@ -99,11 +99,11 @@ void WaylandKeyboard::OnKeyNotify(void* data,
       (xkb_state_component)(XKB_STATE_DEPRESSED | XKB_STATE_LATCHED));
   device->keyboard_modifiers_ = 0;
   if (mask & device->xkb_.control_mask)
-    device->keyboard_modifiers_ |= EF_CONTROL_DOWN;
+    device->keyboard_modifiers_ |= ui::EF_CONTROL_DOWN;
   if (mask & device->xkb_.alt_mask)
-    device->keyboard_modifiers_ |= EF_ALT_DOWN;
+    device->keyboard_modifiers_ |= ui::EF_ALT_DOWN;
   if (mask & device->xkb_.shift_mask)
-    device->keyboard_modifiers_ |= EF_SHIFT_DOWN;
+    device->keyboard_modifiers_ |= ui::EF_SHIFT_DOWN;
 
   device->dispatcher_->KeyNotify(currentState, sym,
                                  device->keyboard_modifiers_);
@@ -180,4 +180,4 @@ void WaylandKeyboard::OnKeyboardLeave(void* data,
 {
 }
 
-}  // namespace ui
+}  // namespace ozonewayland

--- a/wayland/keyboard.h
+++ b/wayland/keyboard.h
@@ -8,7 +8,7 @@
 #include <xkbcommon/xkbcommon.h>
 #include "ozone/wayland/display.h"
 
-namespace ui {
+namespace ozonewayland {
 
 class WaylandDispatcher;
 
@@ -83,6 +83,6 @@ class WaylandKeyboard {
   DISALLOW_COPY_AND_ASSIGN(WaylandKeyboard);
 };
 
-}  // namespace ui
+}  // namespace ozonewayland
 
 #endif  // OZONE_WAYLAND_KEYBOARD_H_

--- a/wayland/pointer.cc
+++ b/wayland/pointer.cc
@@ -12,7 +12,7 @@
 
 #include <linux/input.h>
 
-namespace ui {
+namespace ozonewayland {
 
 WaylandPointer::WaylandPointer()
   : cursor_(NULL),
@@ -145,4 +145,4 @@ void WaylandPointer::OnPointerLeave(void* data,
                                     device->pointer_position_.y());
 }
 
-}  // namespace ui
+}  // namespace ozonewayland

--- a/wayland/pointer.h
+++ b/wayland/pointer.h
@@ -7,7 +7,7 @@
 
 #include "ui/gfx/point.h"
 
-namespace ui {
+namespace ozonewayland {
 
 class WaylandCursor;
 class WaylandDispatcher;
@@ -67,6 +67,6 @@ class WaylandPointer {
   DISALLOW_COPY_AND_ASSIGN(WaylandPointer);
 };
 
-}  // namespace ui
+}  // namespace ozonewayland
 
 #endif  // OZONE_WAYLAND_POINTER_H_

--- a/wayland/screen.cc
+++ b/wayland/screen.cc
@@ -10,7 +10,7 @@
 
 #include <wayland-client.h>
 
-namespace ui {
+namespace ozonewayland {
 
 WaylandScreen::WaylandScreen(WaylandDisplay* display, uint32_t id)
     : output_(NULL)
@@ -59,10 +59,8 @@ void WaylandScreen::OutputHandleMode(void* data,
       screen->rect_.set_width(width);
       screen->rect_.set_height(height);
       screen->refresh_ = refresh;
-      OzoneWayland::OzoneDisplay::GetInstance()->OnOutputSizeChanged(screen,
-                                                                     width,
-                                                                     height);
+      OzoneDisplay::GetInstance()->OnOutputSizeChanged(screen, width, height);
   }
 }
 
-}  // namespace ui
+}  // namespace ozonewayland

--- a/wayland/screen.h
+++ b/wayland/screen.h
@@ -16,7 +16,7 @@
 
 struct wl_output;
 
-namespace ui {
+namespace ozonewayland {
 
 class WaylandDisplay;
 
@@ -57,6 +57,6 @@ class WaylandScreen {
   DISALLOW_COPY_AND_ASSIGN(WaylandScreen);
 };
 
-}  // namespace ui
+}  // namespace ozonewayland
 
 #endif  // OZONE_WAYLAND_SCREEN_H_

--- a/wayland/shell_surface.cc
+++ b/wayland/shell_surface.cc
@@ -9,7 +9,7 @@
 
 #include "base/logging.h"
 
-namespace ui {
+namespace ozonewayland {
 
 WaylandShellSurface::WaylandShellSurface(WaylandWindow* window)
     : surface_(NULL),
@@ -85,4 +85,4 @@ void WaylandShellSurface::HandlePing(void *data, struct wl_shell_surface *shell_
   wl_shell_surface_pong(shell_surface, serial);
 }
 
-}  // namespace ui
+}  // namespace ozonewayland

--- a/wayland/shell_surface.h
+++ b/wayland/shell_surface.h
@@ -8,7 +8,7 @@
 #include "ozone/wayland/display.h"
 #include "ozone/wayland/window.h"
 
-namespace ui {
+namespace ozonewayland {
 
 class WaylandSurface;
 class WaylandWindow;
@@ -32,6 +32,6 @@ class WaylandShellSurface {
   DISALLOW_COPY_AND_ASSIGN(WaylandShellSurface);
 };
 
-}  // namespace ui
+}  // namespace ozonewayland
 
 #endif  // OZONE_WAYLAND_SHELL_SURFACE_H_

--- a/wayland/surface.cc
+++ b/wayland/surface.cc
@@ -6,7 +6,7 @@
 #include "ozone/wayland/surface.h"
 #include "ozone/wayland/display.h"
 
-namespace ui {
+namespace ozonewayland {
 static const struct wl_callback_listener frameListener = {
     WaylandSurface::surfaceFrameCallback
 };

--- a/wayland/surface.h
+++ b/wayland/surface.h
@@ -8,7 +8,7 @@
 #include <wayland-client.h>
 #include <wayland-server.h>
 
-namespace ui {
+namespace ozonewayland {
 
 class WaylandDisplay;
 
@@ -45,6 +45,6 @@ private:
   struct wl_event_queue* m_queue;
 };
 
-}  // namespace ui
+}  // namespace ozonewayland
 
 #endif  // OZONE_WAYLAND_DISPLAY_H_

--- a/wayland/window.cc
+++ b/wayland/window.cc
@@ -11,7 +11,7 @@
 
 #include "base/logging.h"
 
-namespace ui {
+namespace ozonewayland {
 
 WaylandWindow::WaylandWindow(ShellType type)
     : shell_surface_(NULL),
@@ -91,4 +91,4 @@ void WaylandWindow::HandleSwapBuffers()
   shell_surface_->Surface()->addFrameCallBack();
 }
 
-}  // namespace ui
+}  // namespace ozonewayland

--- a/wayland/window.h
+++ b/wayland/window.h
@@ -11,7 +11,7 @@
 
 #include <stdint.h>
 
-namespace ui {
+namespace ozonewayland {
 
 class WaylandShellSurface;
 class EGLWindow;
@@ -59,6 +59,6 @@ class WaylandWindow {
   DISALLOW_COPY_AND_ASSIGN(WaylandWindow);
 };
 
-}  // namespace ui
+}  // namespace ozonewayland
 
 #endif  // OZONE_WAYLAND_WINDOW_H_


### PR DESCRIPTION
This patch unifies the name spaces of all classes in ozone-wayland to
ozonewayland.
