### PR TITLE
Add support to pass state information from WindowHost to window.

### DIFF
--- a/impl/desktop_root_window_host_wayland.h
+++ b/impl/desktop_root_window_host_wayland.h
@@ -45,6 +45,17 @@ class VIEWS_EXPORT DesktopRootWindowHostWayland :
   void HandleNativeWidgetActivationChanged(bool active);
 
  private:
+  enum RootWindowState {
+    Uninitialized = 0x00,
+    Visible = 0x01, // Window is Visible.
+    FullScreen = 0x02,  // Window is in fullscreen mode.
+    Maximized = 0x04, // Window is maximized,
+    Minimized = 0x08, // Window is minimized.
+    Normal = 0x10, // Window is in Normal Mode.
+    Active = 0x20, // Window is Active.
+  };
+
+  typedef unsigned RootWindowState;
   // Initializes our Ozone surface to draw on. This method performs all
   // initialization related to talking to the Ozone server.
   void InitWaylandWindow(const views::Widget::InitParams& params);
@@ -169,8 +180,7 @@ class VIEWS_EXPORT DesktopRootWindowHostWayland :
   gfx::AcceleratedWidget window_;
   views::internal::NativeWidgetDelegate* native_widget_delegate_;
 
-  // Is the window mapped to the screen?
-  bool window_mapped_;
+  RootWindowState state_;
 
   gfx::Rect bounds_;
 

--- a/impl/ipc/display_channel.cc
+++ b/impl/ipc/display_channel.cc
@@ -40,6 +40,7 @@ bool OzoneDisplayChannel::OnMessageReceived(
   bool handled = true;
   IPC_BEGIN_MESSAGE_MAP(OzoneDisplayChannel, message)
   IPC_MESSAGE_HANDLER(WaylandMsg_DisplayChannelEstablished, OnEstablishChannel)
+  IPC_MESSAGE_HANDLER(WaylandWindow_State, OnWidgetStateChanged)
   IPC_MESSAGE_UNHANDLED(handled = false)
   IPC_END_MESSAGE_MAP()
 
@@ -70,6 +71,11 @@ void OzoneDisplayChannel::Register()
     thread->Send(new WaylandMsg_EstablishDisplayChannel(display_fd_));
     thread->AddRoute(display_fd_, this);
   }
+}
+
+void OzoneDisplayChannel::OnWidgetStateChanged(unsigned handleid, unsigned state)
+{
+  OzoneDisplay::GetInstance()->OnWidgetStateChanged(handleid, state);
 }
 
 }  // namespace ozonewayland

--- a/impl/ipc/display_channel.h
+++ b/impl/ipc/display_channel.h
@@ -25,6 +25,7 @@ class OzoneDisplayChannel : public IPC::Listener
 
   void OnEstablishChannel(unsigned route_id);
   void Register();
+  void OnWidgetStateChanged(unsigned handleid, unsigned state);
 
  private:
   unsigned display_fd_;

--- a/impl/ipc/display_channel_host.cc
+++ b/impl/ipc/display_channel_host.cc
@@ -45,6 +45,11 @@ void OzoneDisplayChannelHost::ChannelClosed(unsigned process_id)
   process_id_ = 0;
 }
 
+void OzoneDisplayChannelHost::SendWidgetState(unsigned w, unsigned state)
+{
+  Send(new WaylandWindow_State(router_id_, w, state));
+}
+
 void OzoneDisplayChannelHost::OnChannelEstablished(unsigned route_id)
 {
   router_id_ = host_id_ + process_id_ + route_id;

--- a/impl/ipc/display_channel_host.h
+++ b/impl/ipc/display_channel_host.h
@@ -24,6 +24,8 @@ class OzoneDisplayChannelHost : public content::BrowserMessageFilter {
   void EstablishChannel(unsigned process_id);
   void ChannelClosed(unsigned process_id);
 
+  void SendWidgetState(unsigned w, unsigned state);
+
   void OnChannelEstablished(unsigned router_id);
   void OnMotionNotify(float x, float y);
   void OnButtonNotify(int state, int flags, float x, float y);

--- a/impl/ipc/messages.h
+++ b/impl/ipc/messages.h
@@ -39,3 +39,6 @@ IPC_MESSAGE_CONTROL1(WaylandMsg_EstablishDisplayChannel, unsigned /* client id *
 // request.
 IPC_MESSAGE_ROUTED1(WaylandMsg_DisplayChannelEstablished,
                     unsigned /* channel_handle */)
+
+IPC_MESSAGE_ROUTED2(WaylandWindow_State,
+                    unsigned /* window_handle */, unsigned /*state*/)

--- a/impl/ozone_display.cc
+++ b/impl/ozone_display.cc
@@ -188,6 +188,50 @@ void OzoneDisplay::WillDestroyCurrentMessageLoop()
   base::MessageLoop::current()->RemoveDestructionObserver(this);
 }
 
+void OzoneDisplay::SetWidgetState(gfx::AcceleratedWidget w,
+                                  WidgetState state)
+{
+  // TODO(Kalyan): Map w to window.
+  if (host_)
+    host_->SendWidgetState(w, state);
+  else
+    OnWidgetStateChanged(w, state);
+}
+
+void OzoneDisplay::OnWidgetStateChanged(gfx::AcceleratedWidget w,
+                                       WidgetState state)
+{
+  // TODO(Kalyan): Map w to window.
+  switch (state) {
+    case FullScreen:
+      NOTIMPLEMENTED();
+      break;
+    case Maximized:
+      root_window_->Maximize();
+      break;
+    case Minimized:
+      root_window_->Minimize();
+      break;
+    case Restore:
+      root_window_->Restore();
+      break;
+    case Active:
+      NOTIMPLEMENTED();
+      break;
+    case InActive:
+      NOTIMPLEMENTED();
+      break;
+    case Show:
+      NOTIMPLEMENTED();
+      break;
+    case Hide:
+      NOTIMPLEMENTED();
+      break;
+    default:
+      break;
+  }
+}
+
 void OzoneDisplay::EstablishChannel(unsigned id)
 {
   if (!host_)

--- a/impl/ozone_display.h
+++ b/impl/ozone_display.h
@@ -23,6 +23,19 @@ class WaylandScreen;
 class OzoneDisplay : public ui::SurfaceFactoryOzone,
                      public base::MessageLoop::DestructionObserver {
  public:
+  enum WidgetState {
+    Show = 1, // Widget is visible.
+    Hide = 2, // Widget is hidden.
+    FullScreen = 3,  // Widget is in fullscreen mode.
+    Maximized = 4, // Widget is maximized,
+    Minimized = 5, // Widget is minimized.
+    Restore = 6, // Restore Widget.
+    Active = 7, // Widget is Activated.
+    InActive = 8 // Widget is DeActivated.
+  };
+
+  typedef unsigned WidgetState;
+
   static OzoneDisplay* GetInstance();
 
   OzoneDisplay();
@@ -50,6 +63,9 @@ class OzoneDisplay : public ui::SurfaceFactoryOzone,
 
   // MessageLoop::DestructionObserver overrides.
   virtual void WillDestroyCurrentMessageLoop() OVERRIDE;
+
+  void SetWidgetState(gfx::AcceleratedWidget w, WidgetState state);
+  void OnWidgetStateChanged(gfx::AcceleratedWidget w, WidgetState state);
 
  private:
   enum Launch {

--- a/wayland/window.cc
+++ b/wayland/window.cc
@@ -62,6 +62,26 @@ void WaylandWindow::SetShellType(ShellType type)
   }
 }
 
+void WaylandWindow::Maximize()
+{
+  NOTIMPLEMENTED();
+}
+
+void WaylandWindow::Minimize()
+{
+  NOTIMPLEMENTED();
+}
+
+void WaylandWindow::Restore()
+{
+  NOTIMPLEMENTED();
+}
+
+void WaylandWindow::SetFullscreen()
+{
+  NOTIMPLEMENTED();
+}
+
 void WaylandWindow::RealizeAcceleratedWidget()
 {
   if (!window_)

--- a/wayland/window.h
+++ b/wayland/window.h
@@ -36,6 +36,11 @@ class WaylandWindow {
   ~WaylandWindow();
 
   void SetShellType(ShellType type);
+  void Maximize();
+  void Minimize();
+  void Restore();
+  void SetFullscreen();
+
   ShellType Type() const { return type_; }
   WaylandWindowId Handle() const { return id_; }
   void RealizeAcceleratedWidget();


### PR DESCRIPTION
This patch adds necessary IPC support to send any state change notification
from RootWindowHost to wayland window.In single process case, wayland window is
notified directly.
