### PR TITLE
Fix the build with gcc 3.8.1

### DIFF
--- a/impl/desktop_root_window_host_wayland.h
+++ b/impl/desktop_root_window_host_wayland.h
@@ -45,7 +45,7 @@ class VIEWS_EXPORT DesktopRootWindowHostWayland :
   void HandleNativeWidgetActivationChanged(bool active);
 
  private:
-  enum RootWindowState {
+  enum {
     Uninitialized = 0x00,
     Visible = 0x01, // Window is Visible.
     FullScreen = 0x02,  // Window is in fullscreen mode.

--- a/impl/ozone_display.h
+++ b/impl/ozone_display.h
@@ -23,7 +23,7 @@ class WaylandScreen;
 class OzoneDisplay : public ui::SurfaceFactoryOzone,
                      public base::MessageLoop::DestructionObserver {
  public:
-  enum WidgetState {
+  enum {
     Show = 1, // Widget is visible.
     Hide = 2, // Widget is hidden.
     FullScreen = 3,  // Widget is in fullscreen mode.


### PR DESCRIPTION
The declaration as enum and the redeclaration as
unsigned conflicts and cause a compiler error. Use
unnamed enums instead, we are not using the type
for variable declarations anyway.
