### PR TITLE
Ensure InitializeHardware is called.

### DIFF
--- a/impl/desktop_root_window_host_wayland.cc
+++ b/impl/desktop_root_window_host_wayland.cc
@@ -77,13 +77,6 @@ void DesktopRootWindowHostWayland::InitWaylandWindow(
 
   ui::SurfaceFactoryOzone* surface_factory =
           ui::SurfaceFactoryOzone::GetInstance();
-  ui::SurfaceFactoryOzone::HardwareState displayInitialization =
-          surface_factory->InitializeHardware();
-  if (displayInitialization != ui::SurfaceFactoryOzone::INITIALIZED) {
-    LOG(ERROR) << "DesktopRootWindowHostWayland failed to initialize hardware";
-    return;
-  }
-
   window_ = surface_factory->GetAcceleratedWidget();
   surface_factory->AttemptToResizeAcceleratedWidget(window_, params.bounds);
 }

--- a/impl/ozone_display.cc
+++ b/impl/ozone_display.cc
@@ -122,6 +122,8 @@ void OzoneDisplay::ShutdownHardware()
 gfx::AcceleratedWidget OzoneDisplay::GetAcceleratedWidget()
 {
   static int opaque_handle = 0;
+  // Ensure display is initialized.
+  InitializeHardware();
   opaque_handle++;
   CreateWidget(opaque_handle);
 


### PR DESCRIPTION
We rely on an explicit call to InitializeHardware for initializing wayland
display and doing all other needed routines at startup.InitializeHardware
is only guaranteed to be called in GPU process/thread. This patch makes
changes to call this explicitly in GetAcceleratedWidget. We already have
checks in place to ensure the function initializes wayland display only
once per instance. This also fixes crash with Ash shell.
