### PR TITLE
Standardize method names

### DIFF
--- a/impl/event_factory_wayland.cc
+++ b/impl/event_factory_wayland.cc
@@ -17,7 +17,7 @@ static base::LazyInstance<scoped_ptr<EventFactoryWayland> > impl_ =
 EventFactoryWayland::EventFactoryWayland()
     : fd_(-1) {
   LOG(INFO) << "Ozone: EventFactoryWayland";
-  fd_ = wl_display_get_fd(WaylandDisplay::GetInstance()->display());
+  fd_ = wl_display_get_fd(WaylandDisplay::GetInstance()->Display());
   CHECK_GE(fd_, 0);
   bool success = base::MessagePumpOzone::Current()->WatchFileDescriptor(
                             fd_,

--- a/impl/ozone_display.cc
+++ b/impl/ozone_display.cc
@@ -81,7 +81,7 @@ gfx::SurfaceFactoryOzone::HardwareState OzoneDisplay::InitializeHardware()
 
   if (singleProcess || gpuProcess) {
     display_ = new WaylandDisplay();
-    initialized_state_ = display_->display() ? gfx::SurfaceFactoryOzone::INITIALIZED
+    initialized_state_ = display_->Display() ? gfx::SurfaceFactoryOzone::INITIALIZED
                                              : gfx::SurfaceFactoryOzone::FAILED;
   }
 
@@ -95,7 +95,7 @@ gfx::SurfaceFactoryOzone::HardwareState OzoneDisplay::InitializeHardware()
     e_factory_ = new EventFactoryWayland();
     EventFactoryWayland::SetInstance(e_factory_);
   } else if (gpuProcess) {
-    int fd = wl_display_get_fd(display_->display());
+    int fd = wl_display_get_fd(display_->Display());
     dispatcher_ = new WaylandDispatcher(fd);
     channel_ = new OzoneDisplayChannel(fd);
     dispatcher_->PostTask(WaylandDispatcher::Poll);
@@ -113,7 +113,7 @@ gfx::SurfaceFactoryOzone::HardwareState OzoneDisplay::InitializeHardware()
 
 intptr_t OzoneDisplay::GetNativeDisplay()
 {
-  return (intptr_t)display_->display();
+  return (intptr_t)display_->Display();
 }
 
 void OzoneDisplay::ShutdownHardware()

--- a/wayland/dispatcher.cc
+++ b/wayland/dispatcher.cc
@@ -300,7 +300,7 @@ WaylandDispatcher::~WaylandDispatcher()
 
 void WaylandDispatcher::HandleFlush()
 {
-  wl_display* waylandDisp = WaylandDisplay::GetInstance()->display();
+  wl_display* waylandDisp = WaylandDisplay::GetInstance()->Display();
 
   while (wl_display_prepare_read(waylandDisp) != 0)
     wl_display_dispatch_pending(waylandDisp);
@@ -319,7 +319,7 @@ void  WaylandDispatcher::DisplayRun(WaylandDispatcher* data)
   // Adopted from:
   // http://cgit.freedesktop.org/wayland/weston/tree/clients/window.c#n5531.
   while (1) {
-    wl_display* waylandDisp = WaylandDisplay::GetInstance()->display();
+    wl_display* waylandDisp = WaylandDisplay::GetInstance()->Display();
     wl_display_dispatch_pending(waylandDisp);
 
     if (!data->running)

--- a/wayland/display.cc
+++ b/wayland/display.cc
@@ -24,22 +24,23 @@ WaylandDisplay::WaylandDisplay() : compositor_(NULL),
 
   instance_ = this;
   static const struct wl_registry_listener registry_listener = {
-    WaylandDisplay::DisplayHandleGlobal
+    .global = WaylandDisplay::DisplayHandleGlobal,
+    .global_remove = WaylandDisplay::DisplayHandleGlobalRemove,
   };
 
   registry_ = wl_display_get_registry(display_);
   wl_registry_add_listener(registry_, &registry_listener, this);
 
   if (wl_display_roundtrip(display_) < 0)
-    terminate();
+    Terminate();
 }
 
 WaylandDisplay::~WaylandDisplay()
 {
-  terminate();
+  Terminate();
 }
 
-void WaylandDisplay::terminate()
+void WaylandDisplay::Terminate()
 {
   for (std::list<WaylandInputDevice*>::iterator i = input_list_.begin();
       i != input_list_.end(); ++i) {
@@ -105,6 +106,12 @@ void WaylandDisplay::DisplayHandleGlobal(void *data,
     disp->shm_ = static_cast<wl_shm*>(
         wl_registry_bind(registry, name, &wl_shm_interface, 1));
   }
+}
+
+void WaylandDisplay::DisplayHandleGlobalRemove(void *data,
+    struct wl_registry *registry,
+    uint32_t name)
+{
 }
 
 }  // namespace ozonewayland

--- a/wayland/display.h
+++ b/wayland/display.h
@@ -26,25 +26,24 @@ class OzoneDisplay;
 // the Wayland compositor, shell, screens, input devices, ...
 class WaylandDisplay {
  public:
-  static WaylandDisplay* GetInstance() { return instance_; }
-  // Returns a pointer to wl_display.
-  wl_display* display() const { return display_; }
-
-  wl_registry* registry() const { return registry_; }
+  static inline WaylandDisplay* GetInstance() { return instance_; }
 
   // Returns a list of the registered screens.
-  std::list<WaylandScreen*> GetScreenList() const { return screen_list_; }
-  WaylandScreen* PrimaryScreen() const { return primary_screen_ ; }
+  inline std::list<WaylandScreen*> GetScreenList() const { return screen_list_; }
+  inline WaylandScreen* PrimaryScreen() const { return primary_screen_ ; }
 
-  wl_shell* shell() const { return shell_; }
-
-  wl_shm* shm() const { return shm_; }
-  wl_compositor* GetCompositor() { return compositor_; }
+  // Accessors
+  inline wl_display* Display() const { return display_; }
+  inline wl_compositor* Compositor() { return compositor_; }
+  inline wl_registry* Registry() const { return registry_; }
+  inline wl_shell* Shell() const { return shell_; }
+  inline wl_shm* Shm() const { return shm_; }
 
  private:
   WaylandDisplay();
   virtual ~WaylandDisplay();
-  void terminate();
+  void Terminate();
+
   // This handler resolves all server events used in initialization. It also
   // handles input device registration, screen registration.
   static void DisplayHandleGlobal(
@@ -53,6 +52,11 @@ class WaylandDisplay {
       uint32_t name,
       const char *interface,
       uint32_t version);
+
+  static void DisplayHandleGlobalRemove(
+      void *data,
+      struct wl_registry *registry,
+      uint32_t name);
 
   // WaylandDisplay manages the memory of all these pointers.
   wl_display* display_;

--- a/wayland/global.h
+++ b/wayland/global.h
@@ -37,5 +37,5 @@ enum BoundsChangeType
 
 }  // namespace ozonewayland
 
-#endif  // OZONE_WAYLAND_DISPLAY_H_
+#endif  // OZONE_WAYLAND_GLOBAL_H_
 

--- a/wayland/input_device.cc
+++ b/wayland/input_device.cc
@@ -22,7 +22,7 @@ WaylandInputDevice::WaylandInputDevice(WaylandDisplay* display, uint32_t id)
   };
 
   input_seat_ = static_cast<wl_seat*>(
-      wl_registry_bind(display->registry(), id, &wl_seat_interface, 1));
+      wl_registry_bind(display->Registry(), id, &wl_seat_interface, 1));
   wl_seat_add_listener(input_seat_, &kInputSeatListener, this);
   wl_seat_set_user_data(input_seat_, this);
 }
@@ -42,12 +42,12 @@ WaylandInputDevice::~WaylandInputDevice()
     delete input_method_filter_;
 }
 
-InputMethod* WaylandInputDevice::GetInputMethod() const
+ui::InputMethod* WaylandInputDevice::InputMethod() const
 {
   if (!input_method_filter_)
     input_method_filter_ = new WaylandInputMethodEventFilter;
 
-  input_method_filter_->GetInputMethod();
+  return input_method_filter_->InputMethod();
 }
 
 void WaylandInputDevice::OnSeatCapabilities(void *data,

--- a/wayland/input_device.h
+++ b/wayland/input_device.h
@@ -8,12 +8,15 @@
 #include "base/basictypes.h"
 #include <wayland-client.h>
 
+namespace ui {
+class InputMethod;
+}
+
 namespace ozonewayland {
 
 class Event;
 class WaylandKeyboard;
 class WaylandPointer;
-class InputMethod;
 class WaylandInputMethodEventFilter;
 class WaylandDisplay;
 
@@ -22,10 +25,10 @@ class WaylandInputDevice {
   WaylandInputDevice(WaylandDisplay* display, uint32_t id);
   ~WaylandInputDevice();
 
-  wl_seat* GetInputSeat() { return input_seat_; }
-  InputMethod* GetInputMethod() const;
-  WaylandKeyboard* GetKeyBoard() const { return input_keyboard_; }
-  WaylandPointer* GetPointer() const { return input_pointer_; }
+  inline wl_seat* InputSeat() { return input_seat_; }
+  inline ui::InputMethod* InputMethod() const;
+  inline WaylandKeyboard* Keyboard() const { return input_keyboard_; }
+  inline WaylandPointer* Pointer() const { return input_pointer_; }
 
  private:
   static void OnSeatCapabilities(void *data,

--- a/wayland/inputs/cursor.cc
+++ b/wayland/inputs/cursor.cc
@@ -109,7 +109,7 @@ void WaylandCursor::Update(CursorType type, uint32_t serial)
     return;
 
   ValidateBuffer(type, serial);
-  struct wl_surface* surface = pointer_surface_->wlSurface();
+  struct wl_surface* surface = pointer_surface_->Surface();
   wl_surface_attach(surface, buffer_, 0, 0);
   wl_surface_damage(surface, 0, 0, width_, height_);
   wl_surface_commit(surface);
@@ -132,7 +132,7 @@ void WaylandCursor::ValidateBuffer(CursorType type, uint32_t serial)
   height_ = image->height;
   wl_pointer_set_cursor(input_pointer_,
                         serial,
-                        pointer_surface_->wlSurface(),
+                        pointer_surface_->Surface(),
                         image->hotspot_x,
                         image->hotspot_y);
 }

--- a/wayland/inputs/input_method_event_filter.h
+++ b/wayland/inputs/input_method_event_filter.h
@@ -23,7 +23,7 @@ class WaylandInputMethodEventFilter
   WaylandInputMethodEventFilter();
   virtual ~WaylandInputMethodEventFilter();
 
-  ui::InputMethod* GetInputMethod() const { return input_method_.get(); }
+  inline ui::InputMethod* InputMethod() const { return input_method_.get(); }
 
  private:
   // Overridden from ui::internal::InputMethodDelegate.

--- a/wayland/inputs/pointer.cc
+++ b/wayland/inputs/pointer.cc
@@ -38,7 +38,7 @@ void WaylandPointer::OnSeatCapabilities(wl_seat *seat, uint32_t caps)
   };
 
   if (!cursor_)
-   cursor_ = new WaylandCursor(WaylandDisplay::GetInstance()->shm());
+   cursor_ = new WaylandCursor(WaylandDisplay::GetInstance()->Shm());
 
   dispatcher_ = WaylandDispatcher::GetInstance();
 

--- a/wayland/screen.cc
+++ b/wayland/screen.cc
@@ -21,7 +21,7 @@ WaylandScreen::WaylandScreen(WaylandDisplay* display, uint32_t id)
   };
 
   output_ = static_cast<wl_output*>(
-      wl_registry_bind(display->registry(), id, &wl_output_interface, 1));
+      wl_registry_bind(display->Registry(), id, &wl_output_interface, 1));
   wl_output_add_listener(output_, &kOutputListener, this);
 }
 

--- a/wayland/shell_surface.cc
+++ b/wayland/shell_surface.cc
@@ -19,10 +19,10 @@ WaylandShellSurface::WaylandShellSurface(WaylandWindow* window)
       return;
 
   surface_ = new WaylandSurface();
-  if (display->shell()) {
+  if (display->Shell()) {
     shell_surface_ = wl_shell_get_shell_surface(
-        display->shell(),
-        surface_->wlSurface());
+        display->Shell(),
+        surface_->Surface());
     UpdateShellSurface(window->Type());
   }
 

--- a/wayland/shell_surface.h
+++ b/wayland/shell_surface.h
@@ -21,7 +21,7 @@ class WaylandShellSurface {
   ~WaylandShellSurface();
 
   void UpdateShellSurface(WaylandWindow::ShellType type) const;
-  WaylandSurface* Surface() const { return surface_; }
+  inline WaylandSurface* Surface() const { return surface_; }
 
   static void HandleConfigure(void *data,
                               struct wl_shell_surface *shell_surface,

--- a/wayland/surface.cc
+++ b/wayland/surface.cc
@@ -16,13 +16,13 @@ WaylandSurface::WaylandSurface() : surface_(NULL),
     m_queue(NULL)
 {
   WaylandDisplay* display = WaylandDisplay::GetInstance();
-  surface_ = wl_compositor_create_surface(display->GetCompositor());
+  surface_ = wl_compositor_create_surface(display->Compositor());
 
   if (!surface_)
     return;
 
-  m_queue = wl_display_create_queue(display->display());
-  wl_proxy_set_queue((struct wl_proxy *)display->registry(), m_queue);
+  m_queue = wl_display_create_queue(display->Display());
+  wl_proxy_set_queue((struct wl_proxy *)display->Registry(), m_queue);
 }
 
 WaylandSurface::~WaylandSurface()
@@ -59,7 +59,7 @@ int WaylandSurface::EnsureFrameCallBackDone()
     return -1;
 
   int ret = 0;
-  wl_display* display = WaylandDisplay::GetInstance()->display();
+  wl_display* display = WaylandDisplay::GetInstance()->Display();
 
   if (frameCallBack_) {
     while (frameCallBack_ && ret != -1)

--- a/wayland/surface.h
+++ b/wayland/surface.h
@@ -15,23 +15,23 @@ class WaylandSurface {
 public:
   WaylandSurface();
   virtual ~WaylandSurface();
-  struct wl_surface* wlSurface() const { return surface_; }
+  inline struct wl_surface* Surface() const { return surface_; }
 
   // FrameCallBack.
   // Example usage to swap buffers
-  // if (m_surface->ensureFrameCallBackDone() == -1)
+  // if (m_surface->EnsureFrameCallBackDone() == -1)
   //    return;
-  // m_surface->addFrameCallBack();
+  // m_surface->AddFrameCallBack();
   // Swap buffers.
   void AddFrameCallBack();
   // Ensure deleteFrameCallBack(in case a framecallback is requested)
   // is called before destroying any EGL resources associated with the
   // surface. Example usage:
-  // deleteFrameCallBack();
+  // DeleteFrameCallBack();
   // destroy egl window etc
   // m_surface = nullptr; i.e destroy WaylandSurface.
   void DeleteFrameCallBack();
-  // see addFrameCallBack.
+  // see AddFrameCallBack.
   int EnsureFrameCallBackDone();
 
   // callback
@@ -46,4 +46,4 @@ private:
 
 }  // namespace ozonewayland
 
-#endif  // OZONE_WAYLAND_DISPLAY_H_
+#endif  // OZONE_WAYLAND_SURFACE_H_

--- a/wayland/window.cc
+++ b/wayland/window.cc
@@ -80,7 +80,7 @@ void WaylandWindow::SetFullscreen()
 void WaylandWindow::RealizeAcceleratedWidget()
 {
   if (!window_)
-    window_ = new EGLWindow(shell_surface_->Surface()->wlSurface(),
+    window_ = new EGLWindow(shell_surface_->Surface()->Surface(),
                             allocation_.width(), allocation_.height());
 }
 

--- a/wayland/window.h
+++ b/wayland/window.h
@@ -41,7 +41,7 @@ class WaylandWindow {
   void Restore();
   void SetFullscreen();
 
-  ShellType Type() const { return type_; }
+  inline ShellType Type() const { return type_; }
   void RealizeAcceleratedWidget();
   void HandleSwapBuffers();
 
@@ -50,7 +50,7 @@ class WaylandWindow {
   wl_egl_window* egl_window() const;
 
   bool SetBounds(const gfx::Rect& new_bounds);
-  gfx::Rect GetBounds() const { return allocation_; }
+  inline gfx::Rect GetBounds() const { return allocation_; }
 
  private:
   WaylandShellSurface* shell_surface_;


### PR DESCRIPTION
This patch renames all methods to start with a capital letter, and for
the case of accessors, remove the 'Get' prefix and declare those as
'inline'.

Signed-off-by: Eduardo Lima (Etrunko) eduardo.lima@intel.com
