### PR TITLE
wayland.gyp: Lower Mesa and Wayland version requirements.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Kalyan Kondapally <kalyan.kondapally@intel.com>
 Tiago Vignatti <tiago.vignatti@intel.com>
 Daniel Narvaez <dwnarvaez@gmail.com>
+Raphael Kubo da Costa <raphael.kubo.da.costa@intel.com>

--- a/wayland/wayland.gyp
+++ b/wayland/wayland.gyp
@@ -19,8 +19,8 @@
       'target_name': 'wayland_toolkit',
       'type': 'static_library',
       'variables': {
-        'WAYLAND_VERSION': '1.2.9',
-        'MESA_VERSION': '9.3',
+        'WAYLAND_VERSION': '1.2.0',
+        'MESA_VERSION': '9.1.3',
         'wayland_packages': [
           'wayland-client >= <(WAYLAND_VERSION)',
           'wayland-cursor >= <(WAYLAND_VERSION)',


### PR DESCRIPTION
Require at least the versions currently available in Tizen IVI, otherwise the
build will just fail. We are not entirely sure everything works with those
slightly old Wayland and Mesa versions, but doing this should at least allow
us to create RPMs to test.
