### PR TITLE
Fix argument order in wl_egl_window_resize

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ Daniel Narvaez <dwnarvaez@gmail.com>
 Raphael Kubo da Costa <raphael.kubo.da.costa@intel.com>
 Michael Spang <spang@chromium.org>
 Eduardo Lima (Etrunko) <eduardo.lima@intel.com>
+Michael Forney <mforney@mforney.org>

--- a/wayland/egl/egl_window.cc
+++ b/wayland/egl/egl_window.cc
@@ -27,7 +27,7 @@ bool EGLWindow::Resize(WaylandSurface* surface, int32_t width, int32_t height)
   surface->EnsureFrameCallBackDone();
 
   // TODO(kalyan): Check if we need to sync display here.
-  wl_egl_window_resize(window_, 0, 0, width, height);
+  wl_egl_window_resize(window_, width, height, 0, 0);
   return true;
 }
 


### PR DESCRIPTION
The prototype is:

```
void wl_egl_window_resize(struct wl_egl_window *egl_window,
                          int width, int height, int dx, int dy)
```

This fixes #151
