### PR TITLE
Export DesktopFactoryWayland and OzoneDisplay.

### DIFF
--- a/impl/desktop_factory_wayland.h
+++ b/impl/desktop_factory_wayland.h
@@ -6,6 +6,7 @@
 #define OZONE_IMPL_DESKTOP_FACTORY_WAYLAND_H_
 
 #include "base/compiler_specific.h"
+#include "ozone/platform/ozone_export_wayland.h"
 #include "ui/views/widget/desktop_aura/desktop_factory_ozone.h"
 
 namespace ozonewayland {
@@ -15,7 +16,8 @@ namespace ozonewayland {
 // TODO(spang): Chromium needs to move desktop support into ui/base so we don't
 // reference views from ozone platform code. This module has an undeclared
 // dependency on views.
-class DesktopFactoryWayland : public views::DesktopFactoryOzone {
+class OZONE_WAYLAND_EXPORT DesktopFactoryWayland
+    : public views::DesktopFactoryOzone {
  public:
   DesktopFactoryWayland();
   virtual ~DesktopFactoryWayland();

--- a/impl/ozone_display.h
+++ b/impl/ozone_display.h
@@ -7,6 +7,7 @@
 
 #include "base/compiler_specific.h"
 #include "base/message_loop/message_loop.h"
+#include "ozone/platform/ozone_export_wayland.h"
 #include "ui/gfx/ozone/surface_factory_ozone.h"
 
 namespace ozonewayland {
@@ -22,8 +23,9 @@ class WaylandDispatcher;
 class WaylandScreen;
 class WindowChangeObserver;
 
-class OzoneDisplay : public gfx::SurfaceFactoryOzone,
-                     public base::MessageLoop::DestructionObserver {
+class OZONE_WAYLAND_EXPORT OzoneDisplay
+    : public gfx::SurfaceFactoryOzone,
+      public base::MessageLoop::DestructionObserver {
  public:
   enum {
     Create = 1,  // Create a new Widget


### PR DESCRIPTION
Their symbols are needed when building downstream code (such as Crosswalk) 
with -Dcomponent=shared_library.

(cherry picked from commit 5034f59030ee530f968895e2aad90705ff4bac43)
