### PR TITLE
Remove fullscreen_wayland.cc because it is implemented in upstream.

### DIFF
--- a/.DEPS.git
+++ b/.DEPS.git
@@ -1,6 +1,6 @@
 vars = {
   'chromium_url': 'https://chromium.googlesource.com/chromium/src.git',
-  'chromium_rev': '6e2c4c14137cf0e3979f30628f4ac70b02a372dc',
+  'chromium_rev': 'e0aa752b87d9b173993e2a03a17554a756807128',
 }
 
 deps = {

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
 Daniel Narvaez <dwnarvaez@gmail.com>
+Dongseong Hwang <dongseong.hwang@intel.com>
 Eduardo Lima (Etrunko) <eduardo.lima@intel.com>
 Kalyan Kondapally <kalyan.kondapally@intel.com>
 Michael Forney <mforney@mforney.org>

--- a/impl/fullscreen_wayland.cc
+++ b/impl/fullscreen_wayland.cc
@@ -1,9 +1,0 @@
-// Copyright 2013 Intel Corporation. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
-// TODO(kalyan): Query from native window manager if current top level window
-// is full screen or not.
-bool IsFullScreenMode() {
-  return false;
-}

--- a/ozone_impl.gyp
+++ b/ozone_impl.gyp
@@ -31,7 +31,6 @@
         'impl/desktop_drag_drop_client_wayland.h',
         'impl/desktop_screen_wayland.cc',
         'impl/desktop_screen_wayland.h',
-        'impl/fullscreen_wayland.cc',
         'impl/ozone_display.cc',
         'impl/ozone_display.h',
         'impl/surface_factory_wayland.cc',


### PR DESCRIPTION
Remove fullscreen_wayland.cc because it is implemented in upstream.
