### PR TITLE
Cursor: Stop crashing when certain cursors are not found.

### DIFF
--- a/wayland/input/cursor.h
+++ b/wayland/input/cursor.h
@@ -57,6 +57,7 @@ class WaylandCursor {
  private:
   wl_pointer* input_pointer_;
   struct wl_surface* pointer_surface_;
+  CursorType current_cursor_;
   DISALLOW_COPY_AND_ASSIGN(WaylandCursor);
 };
 


### PR DESCRIPTION
Not all cursor themes have all the types we have defined in 
WaylandCursor::CursorType. When that happens, the corresponding entry in 
cursors_ becomes NULL. We were then passing NULL to 
wl_cursor_image_get_buffer() and crashing.

Fix it by falling back to a default cursor type in case
WaylandCursorData::GetCursorImage() fails to return a valid cursor.

TEST=Launch chrome or content_shell with a cursor theme that doesn't have
    "top_left" or another commonly used name, such as the default Wayland
    cursor theme.
