### PR TITLE
Fix the build fix in 2168bce.

### DIFF
--- a/wayland/input/cursor.cc
+++ b/wayland/input/cursor.cc
@@ -35,7 +35,7 @@ class WaylandCursorData {
     }
   }
 
-  struct wl_cursor_image* GetCursorImage(int index);
+  struct wl_cursor_image* GetCursorImage(WaylandCursor::CursorType index);
 
  private:
   wl_cursor_theme* cursor_theme_;
@@ -86,7 +86,7 @@ WaylandCursorData::WaylandCursorData(wl_shm* shm)
     cursors_[i] = wl_cursor_theme_get_cursor(cursor_theme_, cursor_names[i]);
 }
 
-struct wl_cursor_image* WaylandCursorData::GetCursorImage(CursorType type) {
+struct wl_cursor_image* WaylandCursorData::GetCursorImage(WaylandCursor::CursorType type) {
   int index = type - 1;
   const struct wl_cursor* cursor = cursors_.at(index);
   if (!cursor)


### PR DESCRIPTION
```
../../ozone/wayland/input/cursor.cc:89:59: error: 'wl_cursor_image* 
ozonewayland::WaylandCursorData::GetCursorImage' is not a static member of
'class ozonewayland::WaylandCursorData'
../../ozone/wayland/input/cursor.cc:89:59: error: 'CursorType' was not 
declared in this scope
../../ozone/wayland/input/cursor.cc:89:76: error: expected ',' or ';' before
'{' token
```

With GCC 4.8.2 in C++11 mode.
