### PR TITLE
wayland.gyp: Use pkg-config-wrapper from the right location.

### DIFF
--- a/wayland/wayland.gyp
+++ b/wayland/wayland.gyp
@@ -13,7 +13,7 @@
     'enable_xdg_shell%': '<(enable_xdg_shell)',
     'conditions': [
       ['sysroot!=""', {
-        'pkg-config': './pkg-config-wrapper "<(sysroot)" "<(target_arch)"',
+        'pkg-config': '../../build/linux/pkg-config-wrapper "<(sysroot)" "<(target_arch)"',
       }, {
         'pkg-config': 'pkg-config'
       }],


### PR DESCRIPTION
When |sysroot| is set (ie. one is building for ARM, for example), instead of
calling pkg-config directly gyp calls pkg-config-wrapper instead. Refer to it
in the right place: it is in src/build/linux, not src/ozone/wayland.
