### PR TITLE
wayland: Pin Wayland protocol version

### DIFF
--- a/wayland/wayland.gyp
+++ b/wayland/wayland.gyp
@@ -25,11 +25,11 @@
       'target_name': 'wayland_toolkit',
       'type': 'static_library',
       'variables': {
-        'WAYLAND_VERSION': '1.2.0',
+        'WAYLAND_VERSION': '1.4.0',
         'MESA_VERSION': '9.1.3',
         'wayland_packages': [
           'egl >= <(MESA_VERSION)',
-          'wayland-client >= <(WAYLAND_VERSION)',
+          'wayland-client = <(WAYLAND_VERSION)',
           'wayland-cursor >= <(WAYLAND_VERSION)',
           'wayland-egl >= <(MESA_VERSION)',
           'xkbcommon',


### PR DESCRIPTION
We need to be consistent among tests, bugs, etc against Wayland and Weston. I
think we all could develop and productize using the same version therefore, and
this CL attempts to do so.

Eventually we could build up a gyp option to set the desired version at
configuration time like use_wayland_version='1.4.0', but for now let's try to
pin one given version instead.
