### PR TITLE
Stop requiring Weston as a build dependency.

### DIFF
--- a/packaging/rpm/chromium.spec
+++ b/packaging/rpm/chromium.spec
@@ -50,7 +50,6 @@ BuildRequires:  pkgconfig(vconf)
 BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  pkgconfig(wayland-cursor)
 BuildRequires:  pkgconfig(wayland-egl)
-BuildRequires:  pkgconfig(weston)
 BuildRequires:  pkgconfig(xkbcommon)
 
 %description

--- a/wayland/wayland.gyp
+++ b/wayland/wayland.gyp
@@ -32,7 +32,6 @@
           'wayland-client = <(WAYLAND_VERSION)',
           'wayland-cursor = <(WAYLAND_VERSION)',
           'wayland-egl >= <(MESA_VERSION)',
-          'weston = <(WAYLAND_VERSION)',
           'xkbcommon',
         ],
       },


### PR DESCRIPTION
This reverts the dependency on Weston 1.4.0 for building Ozone-Wayland
introduced in commit e57ab035f78d82117e1f1c7ec1459eb0c21deb22.

While it is OK to depend on Wayland and other libraries and even require
specific versions of them, it does not make much sense to do the same
for Weston, since it is not included or linked to by anything during the
build.
