### PR TITLE
Temporarily remove ozone dependency for gl

### DIFF
--- a/patches/0006-Temporarily-remove-ozone-dependency-for-gl.patch
+++ b/patches/0006-Temporarily-remove-ozone-dependency-for-gl.patch
@@ -1,0 +1,34 @@
+From f62cb73e2053d5fda4f031abea007e0a455dac38 Mon Sep 17 00:00:00 2001
+From: jiajia qin <jiajia.qin@intel.com>
+Date: Thu, 24 Jul 2014 18:37:35 +0800
+Subject: [PATCH] Temporarily remove ozone dependency for gl
+
+The old implementation will result that the third party window system can't depend on ui/gl
+because of cycling dependency. So temporarily remove ozone dependency for gl until we find
+a better method to resolve it.
+
+BUG=240
+---
+ ui/gl/gl.gyp | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/ui/gl/gl.gyp b/ui/gl/gl.gyp
+index ac780d7..ba04c0c 100644
+--- a/ui/gl/gl.gyp
++++ b/ui/gl/gl.gyp
+@@ -295,12 +295,6 @@
+         ['OS!="android"', {
+           'sources/': [ ['exclude', '^android/'] ],
+         }],
+-        ['use_ozone==1', {
+-          'dependencies': [
+-            '../ozone/ozone.gyp:ozone',
+-            '../ozone/ozone.gyp:ozone_base',
+-          ],
+-        }],
+         ['OS=="android" and android_webview_build==0', {
+           'dependencies': [
+             '../android/ui_android.gyp:ui_java',
+-- 
+1.8.1.2
+


### PR DESCRIPTION
The old implementation will result that the third party window system can't depend on ui/gl
because of cycling dependency. So temporarily remove ozone dependency for gl until we find a better method to resolve it.

This PR is corresponding to PR-246

BUG=240
