### PR TITLE
Fix crash when unplug the mouse with pointer in the window.

### DIFF
--- a/wayland/input_device.cc
+++ b/wayland/input_device.cc
@@ -169,33 +169,30 @@ void WaylandInputDevice::OnSeatCapabilities(void *data,
   WaylandInputDevice* device = static_cast<WaylandInputDevice*>(data);
   if ((caps & WL_SEAT_CAPABILITY_KEYBOARD) && !device->input_keyboard_) {
     device->input_keyboard_ = new WaylandKeyboard();
+    device->input_keyboard_->OnSeatCapabilities(seat, caps);
   } else if (!(caps & WL_SEAT_CAPABILITY_KEYBOARD) && device->input_keyboard_) {
+    device->input_keyboard_->OnSeatCapabilities(seat, caps);
     delete device->input_keyboard_;
     device->input_keyboard_ = NULL;
   }
 
   if ((caps & WL_SEAT_CAPABILITY_POINTER) && !device->input_pointer_) {
     device->input_pointer_ = new WaylandPointer();
+    device->input_pointer_->OnSeatCapabilities(seat, caps);
   } else if (!(caps & WL_SEAT_CAPABILITY_POINTER) && device->input_pointer_) {
+    device->input_pointer_->OnSeatCapabilities(seat, caps);
     delete device->input_pointer_;
     device->input_pointer_ = NULL;
   }
 
   if ((caps & WL_SEAT_CAPABILITY_TOUCH) && !device->input_touch_) {
     device->input_touch_ = new WaylandTouchscreen();
+    device->input_touch_->OnSeatCapabilities(seat, caps);
   } else if (!(caps & WL_SEAT_CAPABILITY_TOUCH) && device->input_touch_) {
+    device->input_touch_->OnSeatCapabilities(seat, caps);
     delete device->input_touch_;
     device->input_touch_ = NULL;
   }
-
-  if (device->input_keyboard_)
-    device->input_keyboard_->OnSeatCapabilities(seat, caps);
-
-  if (device->input_pointer_)
-    device->input_pointer_->OnSeatCapabilities(seat, caps);
-
-  if (device->input_touch_)
-    device->input_touch_->OnSeatCapabilities(seat, caps);
 }
 
 void WaylandInputDevice::SetFocusWindowHandle(unsigned windowhandle) {


### PR DESCRIPTION
We should call wl_pointer_destroy to remove listener of
pointer after we unplug the mouse.

We should not only call OnSetCapabilities after we create input
but also call OnSetCapabilities before we destroy them.

BUG=250
