### PR TITLE
Fix compilation after https://codereview.chromium.org/375183002

### DIFF
--- a/ui/desktop_aura/desktop_window_tree_host_wayland.cc
+++ b/ui/desktop_aura/desktop_window_tree_host_wayland.cc
@@ -657,6 +657,10 @@ bool DesktopWindowTreeHostWayland::IsAnimatingClosed() const {
   return false;
 }
 
+bool DesktopWindowTreeHostWin::IsTranslucentWindowOpacitySupported() const {
+  return false;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // DesktopWindowTreeHostWayland, aura::WindowTreeHost implementation:
 

--- a/ui/desktop_aura/desktop_window_tree_host_wayland.h
+++ b/ui/desktop_aura/desktop_window_tree_host_wayland.h
@@ -132,6 +132,7 @@ class VIEWS_EXPORT DesktopWindowTreeHostWayland
   virtual void OnNativeWidgetFocus() OVERRIDE;
   virtual void OnNativeWidgetBlur() OVERRIDE;
   virtual bool IsAnimatingClosed() const OVERRIDE;
+  virtual bool IsTranslucentWindowOpacitySupported() const OVERRIDE;
 
   // Overridden from aura::WindowTreeHost:
   virtual ui::EventSource* GetEventSource() OVERRIDE;


### PR DESCRIPTION
https://codereview.chromium.org/375183002 added a new pure virtual method
IsTranslucentWindowOpacitySupported. We need to at least provide
an empty implementation.

Note that this patch was backported in the M37 branch with
https://codereview.chromium.org/412033002 thus it's needed for whoever
moves to latest version of M37 (note that this patch was not present
in 37.0.2062.20).
