### PR TITLE
Using env variable : OZONE_WAYLAND_USE_XDG_SHELL

### DIFF
--- a/wayland/shell/shell.cc
+++ b/wayland/shell/shell.cc
@@ -57,7 +57,7 @@ void WaylandShell::Initialize(struct wl_registry *registry,
     shell_ = static_cast<wl_shell*>(
         wl_registry_bind(registry, name, &wl_shell_interface, 1));
 #if defined(ENABLE_XDG_SHELL)
-  } else if (strcmp(interface, "xdg_shell") == 0) {
+  } else if ((strcmp(interface, "xdg_shell") == 0) && getenv("OZONE_WAYLAND_USE_XDG_SHELL")) {
       DCHECK(!xdg_shell_);
       xdg_shell_ = static_cast<xdg_shell*>(
           wl_registry_bind(registry, name, &xdg_shell_interface, 1));


### PR DESCRIPTION
(name is inspired from Qt and EFL implementations of xdg-shell)

So far xdg-shell is an extension to weston,
let's make it available at runtime
but make sure to have xdg-shell enabled also at buildtime.

Without this env variable defined (ie: in /etc/profile),
if no other alt shell is selected
then wl-shell will be used as (mandatory) fallback.

Signed-off-by: Philippe Coval philippe.coval@open.eurogiciel.org
