### PR TITLE
Check keyboard modifiers when returning cached symbol code.

### DIFF
--- a/wayland/input/keyboard_engine_xkb.cc
+++ b/wayland/input/keyboard_engine_xkb.cc
@@ -17,6 +17,7 @@ KeyboardEngineXKB::KeyboardEngineXKB() : keyboard_modifiers_(0),
     mods_locked_(0),
     group_(0),
     last_key_(-1),
+    last_modifiers_(0),
     cached_sym_(XKB_KEY_NoSymbol),
     keymap_(NULL),
     state_(NULL),
@@ -92,7 +93,7 @@ void KeyboardEngineXKB::OnKeyModifiers(uint32_t mods_depressed,
 }
 
 unsigned KeyboardEngineXKB::ConvertKeyCodeFromEvdev(unsigned hardwarecode) {
-  if (hardwarecode == last_key_)
+  if (hardwarecode == last_key_ && last_modifiers_ ==  keyboard_modifiers_)
     return cached_sym_;
 
   const xkb_keysym_t *syms;
@@ -105,6 +106,7 @@ unsigned KeyboardEngineXKB::ConvertKeyCodeFromEvdev(unsigned hardwarecode) {
     sym = XKB_KEY_NoSymbol;
 
   last_key_ = hardwarecode;
+  last_modifiers_ =  keyboard_modifiers_;
   cached_sym_ = sym;
   NormalizeKey();
 

--- a/wayland/input/keyboard_engine_xkb.h
+++ b/wayland/input/keyboard_engine_xkb.h
@@ -41,6 +41,7 @@ class KeyboardEngineXKB {
   uint32_t mods_locked_;
   uint32_t group_;
   int last_key_;
+  uint32_t last_modifiers_;
   xkb_keysym_t cached_sym_;
 
   // keymap used to transform keyboard events.


### PR DESCRIPTION
Law keyboard code is converted to XKB code before sending
it to the browser process. At this time, the previous XKB code
is reused when the same law keyboard code is received.
However, "\" and "|" have the same keyboard code, so we distinguish
them with shift key(keyboard modifiers), but keyboard modifiers
have not been considered to reuse the previous XKB code.

This patch allows to check keyboard modifiers to distinguish
between "+" and "=", "\" and "|" when returning cached symbol code.

Bug: XWALK-1997
