### PR TITLE
Define the window bounds as (0,0) when minimizing.

### DIFF
--- a/ui/desktop_aura/desktop_window_tree_host_wayland.cc
+++ b/ui/desktop_aura/desktop_window_tree_host_wayland.cc
@@ -457,8 +457,10 @@ void DesktopWindowTreeHostWayland::Minimize() {
 
   state_ |= Minimized;
   previous_bounds_ = bounds_;
+  bounds_ = gfx::Rect();
   ui::WindowStateChangeHandler::GetInstance()->SetWidgetState(window_,
                                                               ui::MINIMIZED);
+  OnHostResized(bounds_.size());
 }
 
 void DesktopWindowTreeHostWayland::Restore() {
@@ -795,6 +797,9 @@ void DesktopWindowTreeHostWayland::HandleWindowResize(unsigned width,
 
 void DesktopWindowTreeHostWayland::HandleWindowUnminimized() {
   state_ &= ~Minimized;
+  bounds_ = previous_bounds_;
+  previous_bounds_ = gfx::Rect();
+  OnHostResized(bounds_.size());
 }
 
 void DesktopWindowTreeHostWayland::HandleCommit(const std::string& text) {


### PR DESCRIPTION
Propagate the window minimization information to the
content window, so the render side can update its
visibility properly. OnWMStateUpdated() is called by
PropertyNofify event from DispatchEvent() when the
browser is minimized or shown from minimized state.
On Windows, this is realized by calling OnHostResized()
with an empty size. Wayland on Linux should do it, too
(it just does not work on Linux with X11).

Bug: #295

Change-Id: If54d4f6468f97c12ce23c33c3d9934fdb5da815e
Author: Nicolas Guyomard nicolas.guyomard@open.eurogiciel.org
Signed-off-by: Manuel Bachmann manuel.bachmann@open.eurogiciel.org
