### PR TITLE
XDG-Shell: fix popup windows (drop-drow lists)

### DIFF
--- a/wayland/shell/shell.cc
+++ b/wayland/shell/shell.cc
@@ -28,7 +28,8 @@ WaylandShell::~WaylandShell() {
 #endif
 }
 
-WaylandShellSurface* WaylandShell::CreateShellSurface(WaylandWindow* window) {
+WaylandShellSurface* WaylandShell::CreateShellSurface(WaylandWindow* window,
+                                                      WaylandWindow::ShellType type) {
   DCHECK(shell_ || xdg_shell_);
   WaylandDisplay* display = WaylandDisplay::GetInstance();
   DCHECK(display);
@@ -41,7 +42,7 @@ WaylandShellSurface* WaylandShell::CreateShellSurface(WaylandWindow* window) {
     surface = new WLShellSurface();
 
   DCHECK(surface);
-  surface->InitializeShellSurface(window);
+  surface->InitializeShellSurface(window, type);
   wl_surface_set_user_data(surface->GetWLSurface(), window);
   display->FlushDisplay();
 

--- a/wayland/shell/shell.h
+++ b/wayland/shell/shell.h
@@ -8,6 +8,7 @@
 #include <wayland-client.h>
 
 #include "base/basictypes.h"
+#include "ozone/wayland/window.h"
 
 struct xdg_shell;
 namespace ozonewayland {
@@ -22,7 +23,8 @@ class WaylandShell {
   // Creates shell surface for a given WaylandWindow. This can be either
   // wl_shell, xdg_shell or any shell which supports wayland protocol.
   // Ownership is passed to the caller.
-  WaylandShellSurface* CreateShellSurface(WaylandWindow* parent);
+  WaylandShellSurface* CreateShellSurface(WaylandWindow* parent,
+                                          WaylandWindow::ShellType type);
   void Initialize(struct wl_registry *registry,
                   uint32_t name,
                   const char *interface,

--- a/wayland/shell/shell_surface.h
+++ b/wayland/shell/shell_surface.h
@@ -23,7 +23,8 @@ class WaylandShellSurface {
 
   // The implementation should initialize the shell and set up all
   // necessary callbacks.
-  virtual void InitializeShellSurface(WaylandWindow* window) = 0;
+  virtual void InitializeShellSurface(WaylandWindow* window,
+                                      WaylandWindow::ShellType type) = 0;
   virtual void UpdateShellSurface(WaylandWindow::ShellType type,
                                   WaylandShellSurface* shell_parent,
                                   unsigned x,

--- a/wayland/shell/wl_shell_surface.cc
+++ b/wayland/shell/wl_shell_surface.cc
@@ -22,7 +22,8 @@ WLShellSurface::~WLShellSurface() {
   wl_shell_surface_destroy(shell_surface_);
 }
 
-void WLShellSurface::InitializeShellSurface(WaylandWindow* window) {
+void WLShellSurface::InitializeShellSurface(WaylandWindow* window,
+                                            WaylandWindow::ShellType type) {
   DCHECK(!shell_surface_);
   WaylandDisplay* display = WaylandDisplay::GetInstance();
   DCHECK(display);

--- a/wayland/shell/wl_shell_surface.h
+++ b/wayland/shell/wl_shell_surface.h
@@ -17,7 +17,8 @@ class WLShellSurface : public WaylandShellSurface {
   WLShellSurface();
   virtual ~WLShellSurface();
 
-  virtual void InitializeShellSurface(WaylandWindow* window) OVERRIDE;
+  virtual void InitializeShellSurface(WaylandWindow* window,
+                                      WaylandWindow::ShellType type) OVERRIDE;
   virtual void UpdateShellSurface(WaylandWindow::ShellType type,
                                   WaylandShellSurface* shell_parent,
                                   unsigned x,

--- a/wayland/shell/xdg_shell_surface.cc
+++ b/wayland/shell/xdg_shell_surface.cc
@@ -29,28 +29,33 @@ XDGShellSurface::~XDGShellSurface() {
     xdg_popup_destroy(xdg_popup_);
 }
 
-void XDGShellSurface::InitializeShellSurface(WaylandWindow* window) {
+void XDGShellSurface::InitializeShellSurface(WaylandWindow* window,
+                                             WaylandWindow::ShellType type) {
   DCHECK(!xdg_surface_);
+  DCHECK(!xdg_popup_);
   WaylandDisplay* display = WaylandDisplay::GetInstance();
   DCHECK(display);
   WaylandShell* shell = WaylandDisplay::GetInstance()->GetShell();
   DCHECK(shell && shell->GetXDGShell());
-  xdg_surface_ = xdg_shell_get_xdg_surface(shell->GetXDGShell(),
-                                           GetWLSurface());
 
-  static const xdg_surface_listener xdg_surface_listener = {
-    XDGShellSurface::HandleConfigure,
-    XDGShellSurface::HandleChangeState,
-    XDGShellSurface::HandleActivate,
-    XDGShellSurface::HandleDeactivate,
-    XDGShellSurface::HandleDelete
-  };
+  if (type != WaylandWindow::POPUP) {
+    xdg_surface_ = xdg_shell_get_xdg_surface(shell->GetXDGShell(),
+                                             GetWLSurface());
 
-  xdg_surface_add_listener(xdg_surface_,
-                           &xdg_surface_listener,
-                           window);
+    static const xdg_surface_listener xdg_surface_listener = {
+      XDGShellSurface::HandleConfigure,
+      XDGShellSurface::HandleChangeState,
+      XDGShellSurface::HandleActivate,
+      XDGShellSurface::HandleDeactivate,
+      XDGShellSurface::HandleDelete
+    };
 
-  DCHECK(xdg_surface_);
+    xdg_surface_add_listener(xdg_surface_,
+                             &xdg_surface_listener,
+                             window);
+
+    DCHECK(xdg_surface_);
+  }
 }
 
 void XDGShellSurface::UpdateShellSurface(WaylandWindow::ShellType type,

--- a/wayland/shell/xdg_shell_surface.h
+++ b/wayland/shell/xdg_shell_surface.h
@@ -20,7 +20,8 @@ class XDGShellSurface : public WaylandShellSurface {
   XDGShellSurface();
   virtual ~XDGShellSurface();
 
-  virtual void InitializeShellSurface(WaylandWindow* window) OVERRIDE;
+  virtual void InitializeShellSurface(WaylandWindow* window,
+                                      WaylandWindow::ShellType type) OVERRIDE;
   virtual void UpdateShellSurface(WaylandWindow::ShellType type,
                                   WaylandShellSurface* shell_parent,
                                   unsigned x,

--- a/wayland/window.cc
+++ b/wayland/window.cc
@@ -32,7 +32,7 @@ void WaylandWindow::SetShellAttributes(ShellType type) {
 
   if (!shell_surface_) {
     shell_surface_ =
-        WaylandDisplay::GetInstance()->GetShell()->CreateShellSurface(this);
+        WaylandDisplay::GetInstance()->GetShell()->CreateShellSurface(this, type);
   }
 
   type_ = type;
@@ -47,7 +47,7 @@ void WaylandWindow::SetShellAttributes(ShellType type,
 
   if (!shell_surface_) {
     shell_surface_ =
-        WaylandDisplay::GetInstance()->GetShell()->CreateShellSurface(this);
+        WaylandDisplay::GetInstance()->GetShell()->CreateShellSurface(this, type);
     WaylandInputDevice* input = WaylandDisplay::GetInstance()->PrimaryInput();
     input->SetGrabWindowHandle(handle_, 0);
   }


### PR DESCRIPTION
Clicking a HTML drop-down list will create a popup window,
which will make Ozone-Wayland crash if xdg-shell is in use.

 Rationale :
When creating a popup window, wl_shell and xdg-shell behave
differently : while the first will turn an existing shell
surface into a popup, the second will create a whole new
object named "xdg_popup". A wl_surface cannot have a
xdg_surface and xdg_popup associated with it at the same
time, and we cannot even destroy an existing xdg_surface
because the shell intefaces will not be reusable anymore
(weston 1.7.0 will formally enforce this behavior with
"roles").

So the only solution is to make sure an xdg_surface is
never created for a popup window, and we do this by
passing the type in the early window creation process,
which means adding a parameter in a virtual function
and all its overrides.

Bug: XWALK-2594

Change-Id: Id6e4d3a9e98d50e47bc57d3d85315c5d38fb3a48
Signed-off-by: Manuel Bachmann manuel.bachmann@open.eurogiciel.org
