### PR TITLE
Fix the crash that happens when touch device is re-enabled.

### DIFF
--- a/wayland/input/touchscreen.cc
+++ b/wayland/input/touchscreen.cc
@@ -16,10 +16,13 @@ namespace ozonewayland {
 
 WaylandTouchscreen::WaylandTouchscreen()
   : dispatcher_(NULL),
-    pointer_position_(0, 0) {
+    pointer_position_(0, 0),
+    wl_touch_(NULL) {
 }
 
 WaylandTouchscreen::~WaylandTouchscreen() {
+  if (wl_touch_)
+    wl_touch_destroy(wl_touch_);
 }
 
 void WaylandTouchscreen::OnSeatCapabilities(wl_seat *seat, uint32_t caps) {
@@ -34,9 +37,9 @@ void WaylandTouchscreen::OnSeatCapabilities(wl_seat *seat, uint32_t caps) {
   dispatcher_ = ui::EventFactoryOzoneWayland::GetInstance()->EventConverter();
 
   if ((caps & WL_SEAT_CAPABILITY_TOUCH)) {
-    wl_touch* input_touch = wl_seat_get_touch(seat);
-    wl_touch_set_user_data(input_touch, this);
-    wl_touch_add_listener(input_touch, &kInputTouchListener, this);
+    wl_touch_ = wl_seat_get_touch(seat);
+    wl_touch_set_user_data(wl_touch_, this);
+    wl_touch_add_listener(wl_touch_, &kInputTouchListener, this);
   }
 }
 

--- a/wayland/input/touchscreen.h
+++ b/wayland/input/touchscreen.h
@@ -59,6 +59,7 @@ class WaylandTouchscreen {
 
   ui::EventConverterOzoneWayland* dispatcher_;
   gfx::Point pointer_position_;
+  struct wl_touch* wl_touch_;
 
   DISALLOW_COPY_AND_ASSIGN(WaylandTouchscreen);
 };

--- a/wayland/input_device.cc
+++ b/wayland/input_device.cc
@@ -189,7 +189,6 @@ void WaylandInputDevice::OnSeatCapabilities(void *data,
     device->input_touch_ = new WaylandTouchscreen();
     device->input_touch_->OnSeatCapabilities(seat, caps);
   } else if (!(caps & WL_SEAT_CAPABILITY_TOUCH) && device->input_touch_) {
-    device->input_touch_->OnSeatCapabilities(seat, caps);
     delete device->input_touch_;
     device->input_touch_ = NULL;
   }


### PR DESCRIPTION
This patch allows to destroy the wl_touch interface by calling
wl_touch_destroy when touch device is un-plugged or disabled,
which prevents Wayland from passing a dangling pointer of
WaylandTouchscreen to touch event handlers.

Bug: TC-1729
