### PR TITLE
Handle correctly the destruction of a windows

### DIFF
--- a/wayland/display.cc
+++ b/wayland/display.cc
@@ -358,7 +358,7 @@ void WaylandDisplay::Terminate() {
     STLDeleteValues(&widget_map_);
     widget_map_.clear();
   }
-
+  StopProcessingEvents();
   for (std::list<WaylandInputDevice*>::iterator i = input_list_.begin();
       i != input_list_.end(); ++i) {
       delete *i;

--- a/wayland/display_poll_thread.cc
+++ b/wayland/display_poll_thread.cc
@@ -66,6 +66,7 @@ WaylandDisplayPollThread::WaylandDisplayPollThread(wl_display* display)
 
 WaylandDisplayPollThread::~WaylandDisplayPollThread() {
   DCHECK(!polling_.IsSignaled());
+  StopProcessingEvents();
   Stop();
 }
 
@@ -82,6 +83,7 @@ void WaylandDisplayPollThread::StartProcessingEvents() {
 void WaylandDisplayPollThread::StopProcessingEvents() {
   if (polling_.IsSignaled())
     stop_polling_.Signal();
+  Stop();
 }
 
 void  WaylandDisplayPollThread::DisplayRun(WaylandDisplayPollThread* data) {
@@ -110,7 +112,7 @@ void  WaylandDisplayPollThread::DisplayRun(WaylandDisplayPollThread* data) {
 
   // Adopted from:
   // http://cgit.freedesktop.org/wayland/weston/tree/clients/window.c#n5531.
-  while (1) {
+  while (!data->stop_polling_.IsSignaled()) {
     wl_display_dispatch_pending(data->display_);
     ret = wl_display_flush(data->display_);
     if (ret < 0 && errno == EAGAIN) {


### PR DESCRIPTION
The task WaylandDisplayPollThread associated to a widget is never stopped

BUG-Tizen=TC-1835

Signed-off-by: Baptiste DURAND baptiste.durand@open.eurogiciel.org
