### PR TITLE
Keep ModelloUI focused after the UI is restored.

### DIFF
--- a/ui/desktop_aura/desktop_window_tree_host_wayland.cc
+++ b/ui/desktop_aura/desktop_window_tree_host_wayland.cc
@@ -507,6 +507,8 @@ void DesktopWindowTreeHostWayland::Minimize() {
 }
 
 void DesktopWindowTreeHostWayland::Restore() {
+  g_active_window = this;
+
   if (state_ & Normal)
     return;
 


### PR DESCRIPTION
When the ModelloUI is restored, this patch allows the UI to get focus
in order to handle touch events without connecting a mouse.

Bug: https://github.com/01org/ozone-wayland/issues/314
