### PR TITLE
XDG-Shell: update to 1.6.0

### DIFF
--- a/wayland/shell/xdg-shell-protocol.c
+++ b/wayland/shell/xdg-shell-protocol.c
@@ -1,9 +1,9 @@
-/*
+/* 
  * Copyright © 2008-2013 Kristian Høgsberg
  * Copyright © 2013      Rafael Antognolli
  * Copyright © 2013      Jasper St. Pierre
  * Copyright © 2010-2013 Intel Corporation
- *
+ * 
  * Permission to use, copy, modify, distribute, and sell this
  * software and its documentation for any purpose is hereby granted
  * without fee, provided that the above copyright notice appear in
@@ -15,7 +15,7 @@
  * representations about the suitability of this software for any
  * purpose.  It is provided "as is" without express or implied
  * warranty.
- *
+ * 
  * THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
  * SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
  * FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
@@ -54,6 +54,10 @@ static const struct wl_interface *types[] = {
 	&wl_surface_interface,
 	&wl_seat_interface,
 	NULL,
+	NULL,
+	NULL,
+	&wl_seat_interface,
+	NULL,
 	&wl_seat_interface,
 	NULL,
 	NULL,
@@ -79,30 +83,30 @@ WL_EXPORT const struct wl_interface xdg_shell_interface = {
 
 static const struct wl_message xdg_surface_requests[] = {
 	{ "destroy", "", types + 0 },
-	{ "set_transient_for", "?o", types + 14 },
-	{ "set_margin", "iiii", types + 0 },
+	{ "set_parent", "?o", types + 14 },
 	{ "set_title", "s", types + 0 },
 	{ "set_app_id", "s", types + 0 },
-	{ "move", "ou", types + 15 },
-	{ "resize", "ouu", types + 17 },
-	{ "set_output", "?o", types + 20 },
-	{ "request_change_state", "uuu", types + 0 },
-	{ "ack_change_state", "uuu", types + 0 },
+	{ "show_window_menu", "ouii", types + 15 },
+	{ "move", "ou", types + 19 },
+	{ "resize", "ouu", types + 21 },
+	{ "ack_configure", "u", types + 0 },
+	{ "set_window_geometry", "iiii", types + 0 },
+	{ "set_maximized", "", types + 0 },
+	{ "unset_maximized", "", types + 0 },
+	{ "set_fullscreen", "?o", types + 24 },
+	{ "unset_fullscreen", "", types + 0 },
 	{ "set_minimized", "", types + 0 },
 };
 
 static const struct wl_message xdg_surface_events[] = {
-	{ "configure", "ii", types + 0 },
-	{ "change_state", "uuu", types + 0 },
-	{ "activated", "", types + 0 },
-	{ "deactivated", "", types + 0 },
+	{ "configure", "iiau", types + 0 },
 	{ "close", "", types + 0 },
 };
 
 WL_EXPORT const struct wl_interface xdg_surface_interface = {
 	"xdg_surface", 1,
-	11, xdg_surface_requests,
-	5, xdg_surface_events,
+	14, xdg_surface_requests,
+	2, xdg_surface_events,
 };
 
 static const struct wl_message xdg_popup_requests[] = {
@@ -118,3 +122,4 @@ WL_EXPORT const struct wl_interface xdg_popup_interface = {
 	1, xdg_popup_requests,
 	1, xdg_popup_events,
 };
+

--- a/wayland/shell/xdg_shell_surface.h
+++ b/wayland/shell/xdg_shell_surface.h
@@ -35,16 +35,9 @@ class XDGShellSurface : public WaylandShellSurface {
   static void HandleConfigure(void* data,
                               struct xdg_surface* xdg_surface,
                               int32_t width,
-                              int32_t height);
-  static void HandleChangeState(void* data,
-                                struct xdg_surface* xdg_surface,
-                                uint32_t state,
-                                uint32_t value,
-                                uint32_t serial);
-  static void HandleActivate(void* data,
-                             struct xdg_surface* xdg_surface);
-  static void HandleDeactivate(void* data,
-                               struct xdg_surface* xdg_surface);
+                              int32_t height,
+                              struct wl_array* states,
+                              uint32_t serial);
   static void HandleDelete(void* data,
                            struct xdg_surface* xdg_surface);
 


### PR DESCRIPTION
Allow the OZONE_WAYLAND_USE_XDG_SHELL environment variable
to work with the latest Weston 1.6.0 release. It will not
work with Weston 1.5.0 anymore. Functionality is unchanged.
