### PR TITLE
forced egl config to use 24 bit depth buffer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
 Alexis Menard <alexis.menard@intel.com>
+Andriy Prystupa <prand007@gmail.com>
 Changbin Shao <changbin.shao@intel.com>
 Daniel Narvaez <dwnarvaez@gmail.com>
 Dongseong Hwang <dongseong.hwang@intel.com>

--- a/wayland/display.cc
+++ b/wayland/display.cc
@@ -153,6 +153,12 @@ WaylandDisplay::GetEGLSurfaceProperties(const int32* desired_list) {
     EGL_BLUE_SIZE, 8,
     EGL_GREEN_SIZE, 8,
     EGL_RED_SIZE, 8,
+// According to egl spec depth size defaulted to zero
+// and smallest size preffered.
+// Please see EGL_DEPTH_SIZE description in:
+// https://www.khronos.org/registry/egl/sdk/docs/man/html/eglChooseConfig.xhtml
+// Force depth to 24 bits to have same depth buffer on different platforms.
+    EGL_DEPTH_SIZE, 24,
     EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
     EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
     EGL_NONE


### PR DESCRIPTION
Fix for https://github.com/01org/ozone-wayland/issues/326
Signed-off-by: Andriy Prystupa andriy.prystupa@globallogic.com
