### PR TITLE
Make vkb work on Tizen emulator

### DIFF
--- a/wayland/display.cc
+++ b/wayland/display.cc
@@ -200,8 +200,11 @@ void WaylandDisplay::SetWidgetState(unsigned w,
       NOTIMPLEMENTED() << " INACTIVE " << w;
       break;
     case ui::SHOW:
-      NOTIMPLEMENTED() << " SHOW " << w;
+    {
+      WaylandWindow* widget = GetWidget(w);
+      widget->Show();
       break;
+    }
     case ui::HIDE:
       NOTIMPLEMENTED() << " HIDE " << w;
       break;

--- a/wayland/input/touchscreen.cc
+++ b/wayland/input/touchscreen.cc
@@ -54,6 +54,18 @@ void WaylandTouchscreen::OnTouchDown(void *data,
   WaylandTouchscreen* device = static_cast<WaylandTouchscreen*>(data);
   WaylandDisplay::GetInstance()->SetSerial(serial);
   WaylandInputDevice* input = WaylandDisplay::GetInstance()->PrimaryInput();
+
+  // Need this code when the user clicks on a text input box directly
+  if (!input->GetPointer()) {
+    if (!surface) {
+      input->SetFocusWindowHandle(0);
+      return;
+    }
+    WaylandWindow* window =
+         static_cast<WaylandWindow*>(wl_surface_get_user_data(surface));
+    input->SetFocusWindowHandle(window->Handle());
+  }
+
   if (input->GetFocusWindowHandle() && input->GetGrabButton() == 0)
     input->SetGrabWindowHandle(input->GetFocusWindowHandle(), id);
 

--- a/wayland/window.cc
+++ b/wayland/window.cc
@@ -71,6 +71,11 @@ void WaylandWindow::Minimize() {
   shell_surface_->Minimize();
 }
 
+void WaylandWindow::Show() {
+  WaylandInputDevice* input = WaylandDisplay::GetInstance()->PrimaryInput();
+  input->SetFocusWindowHandle(handle_);
+}
+
 void WaylandWindow::Restore() {
   // If window is created as fullscreen, we don't set/restore any window states
   // like Maximize etc.

--- a/wayland/window.h
+++ b/wayland/window.h
@@ -43,6 +43,7 @@ class WaylandWindow {
   void Minimize();
   void Restore();
   void SetFullscreen();
+  void Show();
 
   ShellType Type() const { return type_; }
   unsigned Handle() const { return handle_; }


### PR DESCRIPTION
VKB does not pop-up on Tizen emulator because mouse events are not
handled. A focused window handle should be passed to
WaylandInputDevice in WaylandPointer::OnPointerEnter, but it is not
called on Tizen emulator. Instead, touch events are fired. So this
patch allows to set window focus when the window shows or touch
events are fired.

Bug=#334
