### PR TITLE
Do not uninitialize input devices when disconnecting the devices.

### DIFF
--- a/wayland/input/keyboard.cc
+++ b/wayland/input/keyboard.cc
@@ -32,9 +32,6 @@ void WaylandKeyboard::OnSeatCapabilities(wl_seat *seat, uint32_t caps) {
     input_keyboard_ = wl_seat_get_keyboard(seat);
     wl_keyboard_add_listener(input_keyboard_, &kInputKeyboardListener,
         this);
-  } else if (!(caps & WL_SEAT_CAPABILITY_KEYBOARD) && input_keyboard_) {
-    wl_keyboard_destroy(input_keyboard_);
-    input_keyboard_ = NULL;
   }
 }
 

--- a/wayland/input/pointer.cc
+++ b/wayland/input/pointer.cc
@@ -46,9 +46,6 @@ void WaylandPointer::OnSeatCapabilities(wl_seat *seat, uint32_t caps) {
       cursor_->SetInputPointer(input_pointer_);
     wl_pointer_set_user_data(input_pointer_, this);
     wl_pointer_add_listener(input_pointer_, &kInputPointerListener, this);
-  } else if (!(caps & WL_SEAT_CAPABILITY_POINTER)
-                && cursor_->GetInputPointer()) {
-    cursor_->SetInputPointer(NULL);
   }
 }
 

--- a/wayland/input_device.cc
+++ b/wayland/input_device.cc
@@ -172,7 +172,6 @@ void WaylandInputDevice::OnSeatCapabilities(void *data,
     device->input_keyboard_ = new WaylandKeyboard();
     device->input_keyboard_->OnSeatCapabilities(seat, caps);
   } else if (!(caps & WL_SEAT_CAPABILITY_KEYBOARD) && device->input_keyboard_) {
-    device->input_keyboard_->OnSeatCapabilities(seat, caps);
     delete device->input_keyboard_;
     device->input_keyboard_ = NULL;
   }
@@ -181,7 +180,6 @@ void WaylandInputDevice::OnSeatCapabilities(void *data,
     device->input_pointer_ = new WaylandPointer();
     device->input_pointer_->OnSeatCapabilities(seat, caps);
   } else if (!(caps & WL_SEAT_CAPABILITY_POINTER) && device->input_pointer_) {
-    device->input_pointer_->OnSeatCapabilities(seat, caps);
     delete device->input_pointer_;
     device->input_pointer_ = NULL;
   }


### PR DESCRIPTION
Each instance of WaylandPointer/WaylandKeyboard is deleted when
the device is disconnected so we don't need to call OnSeatCapabilities
method in order to uninitialize the input device.

Bug=#338
