### PR TITLE
XDG-Shell: update to 1.6.0

### DIFF
--- a/wayland/display.h
+++ b/wayland/display.h
@@ -10,6 +10,12 @@
 #define __STDC_FORMAT_MACROS
 #endif
 
+#define wl_array_for_each_type(type, pos, array) \
+  for (type *pos = reinterpret_cast<type*>((array)->data); \
+       reinterpret_cast<const char*>(pos) < \
+         (reinterpret_cast<const char*>((array)->data) + (array)->size); \
+       pos++)
+
 #include <wayland-client.h>
 #include <list>
 #include <map>

--- a/wayland/shell/xdg-shell-protocol.c
+++ b/wayland/shell/xdg-shell-protocol.c
@@ -1,9 +1,9 @@
-/*
+/* 
  * Copyright © 2008-2013 Kristian Høgsberg
  * Copyright © 2013      Rafael Antognolli
  * Copyright © 2013      Jasper St. Pierre
  * Copyright © 2010-2013 Intel Corporation
- *
+ * 
  * Permission to use, copy, modify, distribute, and sell this
  * software and its documentation for any purpose is hereby granted
  * without fee, provided that the above copyright notice appear in
@@ -15,7 +15,7 @@
  * representations about the suitability of this software for any
  * purpose.  It is provided "as is" without express or implied
  * warranty.
- *
+ * 
  * THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
  * SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
  * FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
@@ -54,6 +54,10 @@ static const struct wl_interface *types[] = {
 	&wl_surface_interface,
 	&wl_seat_interface,
 	NULL,
+	NULL,
+	NULL,
+	&wl_seat_interface,
+	NULL,
 	&wl_seat_interface,
 	NULL,
 	NULL,
@@ -79,30 +83,30 @@ WL_EXPORT const struct wl_interface xdg_shell_interface = {
 
 static const struct wl_message xdg_surface_requests[] = {
 	{ "destroy", "", types + 0 },
-	{ "set_transient_for", "?o", types + 14 },
-	{ "set_margin", "iiii", types + 0 },
+	{ "set_parent", "?o", types + 14 },
 	{ "set_title", "s", types + 0 },
 	{ "set_app_id", "s", types + 0 },
-	{ "move", "ou", types + 15 },
-	{ "resize", "ouu", types + 17 },
-	{ "set_output", "?o", types + 20 },
-	{ "request_change_state", "uuu", types + 0 },
-	{ "ack_change_state", "uuu", types + 0 },
+	{ "show_window_menu", "ouii", types + 15 },
+	{ "move", "ou", types + 19 },
+	{ "resize", "ouu", types + 21 },
+	{ "ack_configure", "u", types + 0 },
+	{ "set_window_geometry", "iiii", types + 0 },
+	{ "set_maximized", "", types + 0 },
+	{ "unset_maximized", "", types + 0 },
+	{ "set_fullscreen", "?o", types + 24 },
+	{ "unset_fullscreen", "", types + 0 },
 	{ "set_minimized", "", types + 0 },
 };
 
 static const struct wl_message xdg_surface_events[] = {
-	{ "configure", "ii", types + 0 },
-	{ "change_state", "uuu", types + 0 },
-	{ "activated", "", types + 0 },
-	{ "deactivated", "", types + 0 },
+	{ "configure", "iiau", types + 0 },
 	{ "close", "", types + 0 },
 };
 
 WL_EXPORT const struct wl_interface xdg_surface_interface = {
 	"xdg_surface", 1,
-	11, xdg_surface_requests,
-	5, xdg_surface_events,
+	14, xdg_surface_requests,
+	2, xdg_surface_events,
 };
 
 static const struct wl_message xdg_popup_requests[] = {
@@ -118,3 +122,4 @@ WL_EXPORT const struct wl_interface xdg_popup_interface = {
 	1, xdg_popup_requests,
 	1, xdg_popup_events,
 };
+

--- a/wayland/shell/xdg_shell_surface.cc
+++ b/wayland/shell/xdg_shell_surface.cc
@@ -44,9 +44,6 @@ void XDGShellSurface::InitializeShellSurface(WaylandWindow* window,
 
     static const xdg_surface_listener xdg_surface_listener = {
       XDGShellSurface::HandleConfigure,
-      XDGShellSurface::HandleChangeState,
-      XDGShellSurface::HandleActivate,
-      XDGShellSurface::HandleDeactivate,
       XDGShellSurface::HandleDelete
     };
 
@@ -65,9 +62,7 @@ void XDGShellSurface::UpdateShellSurface(WaylandWindow::ShellType type,
   switch (type) {
   case WaylandWindow::TOPLEVEL: {
     if (maximized_) {
-      xdg_surface_request_change_state(xdg_surface_,
-                                       XDG_SURFACE_STATE_MAXIMIZED,
-                                       false, 0);
+      xdg_surface_unset_maximized(xdg_surface_);
       maximized_ = false;
     }
     break;
@@ -95,9 +90,8 @@ void XDGShellSurface::UpdateShellSurface(WaylandWindow::ShellType type,
     break;
   }
   case WaylandWindow::FULLSCREEN:
-    xdg_surface_request_change_state(xdg_surface_,
-                                     XDG_SURFACE_STATE_FULLSCREEN,
-                                     true, 0);
+    xdg_surface_set_fullscreen(xdg_surface_,
+                               NULL);
     break;
   case WaylandWindow::CUSTOM:
       NOTREACHED() << "Unsupported shell type: " << type;
@@ -115,9 +109,7 @@ void XDGShellSurface::SetWindowTitle(const base::string16& title) {
 }
 
 void XDGShellSurface::Maximize() {
-  xdg_surface_request_change_state(xdg_surface_,
-                                   XDG_SURFACE_STATE_MAXIMIZED,
-                                   true, 0);
+  xdg_surface_set_maximized(xdg_surface_);
   maximized_ = true;
   WaylandShellSurface::FlushDisplay();
 }
@@ -138,26 +130,18 @@ bool XDGShellSurface::IsMinimized() const {
 void XDGShellSurface::HandleConfigure(void* data,
                                       struct xdg_surface* xdg_surface,
                                       int32_t width,
-                                      int32_t height) {
-  WaylandShellSurface::WindowResized(data, width, height);
-}
+                                      int32_t height,
+                                      struct wl_array* states,
+                                      uint32_t serial) {
+  wl_array_for_each_type(const unsigned int, state, states) {
+    if (*state == XDG_SURFACE_STATE_ACTIVATED)
+      WaylandShellSurface::WindowActivated(data);
+  }
 
-void XDGShellSurface::HandleChangeState(void* data,
-                                        struct xdg_surface* xdg_surface,
-                                        uint32_t state,
-                                        uint32_t value,
-                                        uint32_t serial) {
-  xdg_surface_ack_change_state(xdg_surface, state, value, serial);
-}
+  if ((width > 0) && (height > 0))
+    WaylandShellSurface::WindowResized(data, width, height);
 
-void XDGShellSurface::HandleActivate(void* data,
-                                     struct xdg_surface* xdg_surface) {
-  WaylandShellSurface::WindowActivated(data);
-}
-
-void XDGShellSurface::HandleDeactivate(void* data,
-                                       struct xdg_surface* xdg_surface) {
-  WaylandShellSurface::WindowDeActivated(data);
+  xdg_surface_ack_configure(xdg_surface, serial);
 }
 
 void XDGShellSurface::HandleDelete(void* data,

--- a/wayland/shell/xdg_shell_surface.h
+++ b/wayland/shell/xdg_shell_surface.h
@@ -35,16 +35,9 @@ class XDGShellSurface : public WaylandShellSurface {
   static void HandleConfigure(void* data,
                               struct xdg_surface* xdg_surface,
                               int32_t width,
-                              int32_t height);
-  static void HandleChangeState(void* data,
-                                struct xdg_surface* xdg_surface,
-                                uint32_t state,
-                                uint32_t value,
-                                uint32_t serial);
-  static void HandleActivate(void* data,
-                             struct xdg_surface* xdg_surface);
-  static void HandleDeactivate(void* data,
-                               struct xdg_surface* xdg_surface);
+                              int32_t height,
+                              struct wl_array* states,
+                              uint32_t serial);
   static void HandleDelete(void* data,
                            struct xdg_surface* xdg_surface);
 


### PR DESCRIPTION
Allow the OZONE_WAYLAND_USE_XDG_SHELL environment variable
to work with the latest Weston 1.6.0 release. It will not
work with Weston 1.5.0 anymore. Functionality is unchanged.

(we define a general "wl_array_for_each_type()" macro to
handle "wl_array" types nicely in the future)