### PR TITLE
Make windowDeActivated event work from xdg_shell

### DIFF
--- a/wayland/shell/xdg_shell_surface.cc
+++ b/wayland/shell/xdg_shell_surface.cc
@@ -138,6 +138,10 @@ void XDGShellSurface::HandleConfigure(void* data,
       WaylandShellSurface::WindowActivated(data);
   }
 
+  // When a window is deactivated, states->size is 0
+  if (!states->size)
+    WaylandShellSurface::WindowDeActivated(data);
+
   if ((width > 0) && (height > 0))
     WaylandShellSurface::WindowResized(data, width, height);
 


### PR DESCRIPTION
We need to generate windowDeActivated events in order to deliver
the events to the browser process.

BUG=#346