### PR TITLE
Include desktop_screen.h to export CreateDesktopScreen().

### DIFF
--- a/ui/desktop_aura/desktop_screen_wayland.cc
+++ b/ui/desktop_aura/desktop_screen_wayland.cc
@@ -9,6 +9,7 @@
 #include "ozone/ui/desktop_aura/desktop_window_tree_host_ozone.h"
 #include "ozone/ui/events/event_factory_ozone_wayland.h"
 #include "ui/aura/window.h"
+#include "ui/views/widget/desktop_aura/desktop_screen.h"
 
 namespace views {
 


### PR DESCRIPTION
If that header is not included, the compiler never knows that symbol is
supposed to be exported, and the component=shared_library build breaks.