### PR TITLE
Export more symbols for the shared_library build.

### DIFF
--- a/media/vaapi_wrapper.cc
+++ b/media/vaapi_wrapper.cc
@@ -13,6 +13,7 @@
 #include "base/sys_info.h"
 // Auto-generated for dlopen libva libraries
 #include "media/media/va_stubs.h"
+#include "content/common/content_export.h"
 #include "content/common/gpu/media/vaapi_picture.h"
 #include "third_party/libyuv/include/libyuv.h"
 #if defined(USE_X11)
@@ -138,14 +139,14 @@ static VAProfile ProfileToVAProfile(
   return va_profile;
 }
 
-VASurface::VASurface(VASurfaceID va_surface_id,
+CONTENT_EXPORT VASurface::VASurface(VASurfaceID va_surface_id,
                      const gfx::Size& size,
                      const ReleaseCB& release_cb)
     : va_surface_id_(va_surface_id), size_(size), release_cb_(release_cb) {
   DCHECK(!release_cb_.is_null());
 }
 
-VASurface::~VASurface() {
+CONTENT_EXPORT VASurface::~VASurface() {
   release_cb_.Run(va_surface_id_);
 }
 

--- a/media/video.gypi
+++ b/media/video.gypi
@@ -9,6 +9,9 @@
     'vaapi_wrapper.cc',
     'vaapi_wrapper.h',
   ],
+  'defines': [
+    'CONTENT_IMPLEMENTATION',
+  ],
   'variables': {
     'extra_header': 'media/va_wayland_stub_header.fragment',
     'sig_files': ['va_wayland.sigs'],

--- a/ui/desktop_aura/desktop_platform_screen.h
+++ b/ui/desktop_aura/desktop_platform_screen.h
@@ -5,8 +5,6 @@
 #ifndef OZONE_IMPL_DESKTOP_AURA_DESKTOP_PLATFORM_SCREEN_H__
 #define OZONE_IMPL_DESKTOP_AURA_DESKTOP_PLATFORM_SCREEN_H__
 
-#include "ui/views/views_export.h"
-
 namespace ui {
 class DesktopPlatformScreen;
 }
@@ -15,7 +13,7 @@ namespace views {
 
 // Creates a Native Screen. Caller owns the result. It's just here to avoid
 // custom changes in OzonePlatform.
-VIEWS_EXPORT ui::DesktopPlatformScreen* CreateDesktopPlatformScreen();
+ui::DesktopPlatformScreen* CreateDesktopPlatformScreen();
 
 }  // namespace views
 

--- a/wayland/ozone_wayland_screen.cc
+++ b/wayland/ozone_wayland_screen.cc
@@ -6,6 +6,7 @@
 
 #include "ozone/ui/desktop_aura/desktop_platform_screen.h"
 
+#include "ozone/platform/ozone_export_wayland.h"
 #include "ozone/ui/events/event_factory_ozone_wayland.h"
 #include "ozone/ui/events/output_change_observer.h"
 #include "ozone/wayland/display_poll_thread.h"
@@ -80,7 +81,7 @@ void OzoneWaylandScreen::DisplayHandleOutputOnly(void *data,
 
 namespace views {
 
-ui::DesktopPlatformScreen* CreateDesktopPlatformScreen() {
+OZONE_WAYLAND_EXPORT ui::DesktopPlatformScreen* CreateDesktopPlatformScreen() {
   return new ozonewayland::OzoneWaylandScreen();
 }
 

--- a/wayland/wayland.gyp
+++ b/wayland/wayland.gyp
@@ -33,6 +33,9 @@
           'xkbcommon',
         ],
       },
+      'defines': [
+        'OZONE_WAYLAND_IMPLEMENTATION',
+      ],
       'cflags': [
         '<!@(<(pkg-config) --cflags <(wayland_packages))',
       ],


### PR DESCRIPTION
* Some symbols in vaapi_wrapper.{cc,h} are used by the content/ layer, but
  they were not being properly exported into libwayland.so:
  CONTENT_IMPLEMENTATION was not defined so CONTENT_EXPORT was
  evaluating to nothing, and the VASurface methods were not being
  exported at all.

* Conversely, CreateDesktopPlatformScreen() was declared in the 'views'
  target but implemented by the 'wayland_toolkit' target. We thus need
  to export the implementation, not the declaration, for the symbol to
  be found by the run-time linker.