### PR TITLE
Directly depend on ozone_platform_dri.

### DIFF
--- a/ozone_impl.gyp
+++ b/ozone_impl.gyp
@@ -11,6 +11,7 @@
       'dependencies': [
         '<(DEPTH)/skia/skia.gyp:skia',
         '<(DEPTH)/base/third_party/dynamic_annotations/dynamic_annotations.gyp:dynamic_annotations',
+        '<(DEPTH)/ui/ozone/ozone.gyp:ozone_platform_dri',
         'wayland/wayland.gyp:wayland_toolkit'
       ],
       'include_dirs': [


### PR DESCRIPTION
Several symbols from ui::DriGpuPlatformSupportHost are referenced in
platform/ and wayland/, but libozone_platform_dri.a was not being linked
into libwayland, causing errors when building in shared_library_mode:

```
/usr/bin/ld.gold: warning: hidden symbol 'ui::DriGpuPlatformSupportHost::DriGpuPlatformSupportHost()' in obj/ui/ozone/libozone_platform_dri.a(obj/ui/ozone/platform/dri/ozone_platform_dri.dri_gpu_platform_support_host.o) is referenced by DSO lib/libwayland.so
/usr/bin/ld.gold: warning: hidden symbol 'ui::DriGpuPlatformSupportHost::RegisterHandler(ui::GpuPlatformSupportHost*)' in obj/ui/ozone/libozone_platform_dri.a(obj/ui/ozone/platform/dri/ozone_platform_dri.dri_gpu_platform_support_host.o) is referenced by DSO lib/libwayland.so
/usr/bin/ld.gold: warning: hidden symbol 'ui::DriGpuPlatformSupportHost::AddChannelObserver(ui::ChannelObserver*)' in obj/ui/ozone/libozone_platform_dri.a(obj/ui/ozone/platform/dri/ozone_platform_dri.dri_gpu_platform_support_host.o) is referenced by DSO lib/libwayland.so
/usr/bin/ld.gold: warning: hidden symbol 'ui::DriGpuPlatformSupportHost::RemoveChannelObserver(ui::ChannelObserver*)' in obj/ui/ozone/libozone_platform_dri.a(obj/ui/ozone/platform/dri/ozone_platform_dri.dri_gpu_platform_support_host.o) is referenced by DSO lib/libwayland.so
/usr/bin/ld.gold: error: treating warnings as errors
```