### PR TITLE
Make the VaapiPictureWayland patch work only with Ozone.

### DIFF
--- a/patches/0005-Media-Build-VaapiPictureWayland-as-part-of-Media.patch
+++ b/patches/0005-Media-Build-VaapiPictureWayland-as-part-of-Media.patch
@@ -20,7 +20,7 @@ index 408bcf0..9e5af4a 100644
        ],
      }],
 -    ['target_arch != "arm" and chromeos == 1', {
-+    ['target_arch != "arm"', {
++    ['target_arch != "arm" and use_ozone == 1', {
        'dependencies': [
          '../media/media.gyp:media',
          '../third_party/libyuv/libyuv.gyp:libyuv',


### PR DESCRIPTION
The previous version of the patch made the changes apply even if X11 was
being used, which broke the build since the implementation in ozone/ was
never being built.