### PR TITLE
Return a nullptr in OzonePlatformWayland::CreateNativeDisplayDelegate.

### DIFF
--- a/platform/ozone_platform_wayland.cc
+++ b/platform/ozone_platform_wayland.cc
@@ -76,7 +76,7 @@ class OzonePlatformWayland : public OzonePlatform {
   }
 
   scoped_ptr<NativeDisplayDelegate> CreateNativeDisplayDelegate() override {
-    return scoped_ptr<NativeDisplayDelegate>(new NativeDisplayDelegateOzone());
+    return nullptr;
   }
 
   void InitializeUI() override {


### PR DESCRIPTION
We were returning a default delegate that had stubs in all methods, but
was not an exported symbol. To fix the shared_library build, just return
a nullptr instead.