### PR TITLE
Reset the focused window handle in WaylandInputDevice when closing the window

### DIFF
--- a/wayland/window.cc
+++ b/wayland/window.cc
@@ -22,6 +22,15 @@ WaylandWindow::WaylandWindow(unsigned handle) : shell_surface_(NULL),
 }
 
 WaylandWindow::~WaylandWindow() {
+  WaylandInputDevice* input = WaylandDisplay::GetInstance()->PrimaryInput();
+  if (input) {
+    if (input->GetFocusWindowHandle() == handle_)
+      input->SetFocusWindowHandle(0);
+
+    if (input->GetGrabWindowHandle() == handle_)
+      input->SetGrabWindowHandle(0, 0);
+  }
+
   delete window_;
   delete shell_surface_;
 }


### PR DESCRIPTION
We need to set the focused window handle to null in WaylandInputDevice when closing the window.

Author: Kalyan Kondapally <kalyan.kondapally@intel.com>

Fixes #362