### PR TITLE
Explicitly depend on more targets for the shared_library build.

### DIFF
--- a/ozone_impl.gyp
+++ b/ozone_impl.gyp
@@ -12,6 +12,7 @@
         '<(DEPTH)/skia/skia.gyp:skia',
         '<(DEPTH)/base/third_party/dynamic_annotations/dynamic_annotations.gyp:dynamic_annotations',
         '<(DEPTH)/ui/ozone/ozone.gyp:ozone_platform_dri',
+        '<(DEPTH)/ui/gfx/ipc/gfx_ipc.gyp:gfx_ipc',
         'wayland/wayland.gyp:wayland_toolkit'
       ],
       'include_dirs': [

--- a/ui/events/event.gypi
+++ b/ui/events/event.gypi
@@ -3,6 +3,7 @@
 # found in the LICENSE file.
 {
   'dependencies': [
+    '<(DEPTH)/ipc/ipc.gyp:ipc',
     '<(DEPTH)/ui/events/events.gyp:events',
   ],
   'sources': [

--- a/wayland/wayland.gyp
+++ b/wayland/wayland.gyp
@@ -57,6 +57,7 @@
       },
       'dependencies': [
         '../../base/base.gyp:base',
+        '../../ui/ozone/ozone.gyp:ozone_base',
       ],
       'include_dirs': [
         '../..',


### PR DESCRIPTION
Recent commits have introduced new dependencies on some Chromium
targets, add them to avoid build failures in component=shared_library
mode.