### PR TITLE
Gardening: adapt to https://codereview.chromium.org/1073573002

### DIFF
--- a/ui/events/event_converter_in_process.cc
+++ b/ui/events/event_converter_in_process.cc
@@ -117,15 +117,18 @@ void EventConverterInProcess::PointerLeave(unsigned handle,
 }
 
 void EventConverterInProcess::KeyNotify(ui::EventType type,
-                                        unsigned code) {
-  VirtualKeyNotify(type, code);
+                                        unsigned code,
+                                        int device_id) {
+  VirtualKeyNotify(type, code, device_id);
 }
 
 void EventConverterInProcess::VirtualKeyNotify(ui::EventType type,
-                                               uint32_t key) {
+                                               uint32_t key,
+                                               int device_id) {
   keyboard_.OnKeyChange(key,
-                         type != ui::ET_KEY_RELEASED,
-                         ui::EventTimeForNow(), 0);
+                        type != ui::ET_KEY_RELEASED,
+                        ui::EventTimeForNow(),
+                        device_id);
 }
 
 void EventConverterInProcess::TouchNotify(ui::EventType type,

--- a/ui/events/event_converter_in_process.h
+++ b/ui/events/event_converter_in_process.h
@@ -47,10 +47,10 @@ class EventConverterInProcess : public ui::EventConverterOzoneWayland,
                   int yoffset) override;
   void PointerEnter(unsigned handle, float x, float y) override;
   void PointerLeave(unsigned handle, float x, float y) override;
-  void KeyNotify(ui::EventType type,
-                 unsigned code) override;
+  void KeyNotify(ui::EventType type, unsigned code, int device_id) override;
   void VirtualKeyNotify(ui::EventType type,
-                        uint32_t key) override;
+                        uint32_t key,
+                        int device_id) override;
   void TouchNotify(ui::EventType type,
                    float x,
                    float y,

--- a/ui/events/event_converter_ozone_wayland.h
+++ b/ui/events/event_converter_ozone_wayland.h
@@ -39,9 +39,11 @@ class OZONE_WAYLAND_EXPORT EventConverterOzoneWayland {
   virtual void PointerEnter(unsigned handle, float x, float y) = 0;
   virtual void PointerLeave(unsigned handle, float x, float y) = 0;
   virtual void KeyNotify(ui::EventType type,
-                         unsigned code) = 0;
+                         unsigned code,
+                         int device_id) = 0;
   virtual void VirtualKeyNotify(ui::EventType type,
-                                uint32_t key) = 0;
+                                uint32_t key,
+                                int device_id) = 0;
   virtual void TouchNotify(ui::EventType type,
                            float x,
                            float y,

--- a/ui/events/remote_event_dispatcher.cc
+++ b/ui/events/remote_event_dispatcher.cc
@@ -56,13 +56,15 @@ void RemoteEventDispatcher::PointerLeave(unsigned handle,
 }
 
 void RemoteEventDispatcher::KeyNotify(ui::EventType type,
-                                      unsigned code) {
-  Dispatch(new WaylandInput_KeyNotify(type, code));
+                                      unsigned code,
+                                      int device_id) {
+  Dispatch(new WaylandInput_KeyNotify(type, code, device_id));
 }
 
 void RemoteEventDispatcher::VirtualKeyNotify(ui::EventType type,
-                                             uint32_t key) {
-  Dispatch(new WaylandInput_VirtualKeyNotify(type, key));
+                                             uint32_t key,
+                                             int device_id) {
+  Dispatch(new WaylandInput_VirtualKeyNotify(type, key, device_id));
 }
 
 void RemoteEventDispatcher::TouchNotify(ui::EventType type,

--- a/ui/events/remote_event_dispatcher.h
+++ b/ui/events/remote_event_dispatcher.h
@@ -35,10 +35,10 @@ class RemoteEventDispatcher : public ui::EventConverterOzoneWayland {
                   int yoffset) override;
   void PointerEnter(unsigned handle, float x, float y) override;
   void PointerLeave(unsigned handle, float x, float y) override;
-  void KeyNotify(ui::EventType type,
-                 unsigned code) override;
+  void KeyNotify(ui::EventType type, unsigned code, int device_id) override;
   void VirtualKeyNotify(ui::EventType type,
-                        uint32_t key) override;
+                        uint32_t key,
+                        int device_id) override;
   void TouchNotify(ui::EventType type,
                    float x,
                    float y,

--- a/ui/public/messages.h
+++ b/ui/public/messages.h
@@ -34,14 +34,16 @@ IPC_MESSAGE_CONTROL2(WaylandInput_InitializeXKB,  // NOLINT(readability/fn_size)
                      base::SharedMemoryHandle /*fd*/,
                      uint32_t /*size*/)
 
-IPC_MESSAGE_CONTROL2(WaylandInput_KeyNotify,  // NOLINT(readability/fn_size)
+IPC_MESSAGE_CONTROL3(WaylandInput_KeyNotify,  // NOLINT(readability/fn_size)
                      ui::EventType /*type*/,
-                     unsigned /*code*/)
+                     unsigned /*code*/,
+                     int /*device_id*/)
 
-IPC_MESSAGE_CONTROL2(  // NOLINT(readability/fn_size)
+IPC_MESSAGE_CONTROL3(  // NOLINT(readability/fn_size)
     WaylandInput_VirtualKeyNotify,
     ui::EventType /*type*/,
-    uint32_t /*key*/)
+    uint32_t /*key*/,
+    int /*device_id*/)
 
 IPC_MESSAGE_CONTROL2(WaylandInput_MotionNotify,  // NOLINT(readability/fn_size)
                      float /*x*/,

--- a/wayland/input/keyboard.cc
+++ b/wayland/input/keyboard.cc
@@ -47,8 +47,9 @@ void WaylandKeyboard::OnKeyNotify(void* data,
   WaylandDisplay::GetInstance()->SetSerial(serial);
   if (state == WL_KEYBOARD_KEY_STATE_RELEASED)
     type = ui::ET_KEY_RELEASED;
-
-  device->dispatcher_->KeyNotify(type, key);
+  const uint32_t device_id = wl_proxy_get_id(
+      reinterpret_cast<wl_proxy*>(input_keyboard));
+  device->dispatcher_->KeyNotify(type, key, device_id);
 }
 
 void WaylandKeyboard::OnKeyboardKeymap(void *data,

--- a/wayland/input/text_input.cc
+++ b/wayland/input/text_input.cc
@@ -93,15 +93,16 @@ void WaylandTextInput::OnKeysym(void* data,
                                 uint32_t key,
                                 uint32_t state,
                                 uint32_t modifiers) {
-  // Copid from WaylandKeyboard::OnKeyNotify()
+  // Copied from WaylandKeyboard::OnKeyNotify().
   ui::EventType type = ui::ET_KEY_PRESSED;
   WaylandDisplay::GetInstance()->SetSerial(serial);
   if (state == WL_KEYBOARD_KEY_STATE_RELEASED)
     type = ui::ET_KEY_RELEASED;
-
   ui::EventConverterOzoneWayland* dispatcher =
           ui::EventFactoryOzoneWayland::GetInstance()->GetEventConverter();
-  dispatcher->VirtualKeyNotify(type, key);
+  const uint32_t device_id = wl_proxy_get_id(
+      reinterpret_cast<wl_proxy*>(text_input));
+  dispatcher->VirtualKeyNotify(type, key, device_id);
 }
 
 void WaylandTextInput::OnEnter(void* data,


### PR DESCRIPTION
This CL adds one argument to `KeyboardEvdev::OnKeyChange()`: a unique device ID seemingly corresponding to the keyboard device that generated the event. In oz-wl, we do that by passing the ID we get via `wl_proxy_get_id()`.