### PR TITLE
Allow to build with component=shared_library build flag

### DIFF
--- a/patches/0011-Add-file-picker-support-using-WebUI.patch
+++ b/patches/0011-Add-file-picker-support-using-WebUI.patch
@@ -1,4 +1,4 @@
-From 5af2c83ba775a7992ea0ff5e86d06b787ef11646 Mon Sep 17 00:00:00 2001
+From 7f765529c8905a55bae0e125a6ed67b1f486cece Mon Sep 17 00:00:00 2001
 From: Joone Hur <joone.hur@intel.com>
 Date: Mon, 13 Apr 2015 15:04:05 -0700
 Subject: [PATCH 11/14] Add file picker support using WebUI
@@ -20,11 +20,11 @@ File browsing UI will be added later.
  .../browser/ui/webui/file_picker/file_picker_ui.cc |  46 ++++++
  .../browser/ui/webui/file_picker/file_picker_ui.h  |  24 +++
  .../ui/webui/file_picker/file_picker_web_dialog.cc | 164 +++++++++++++++++++++
- chrome/chrome_browser_ui.gypi                      |   4 +
+ chrome/chrome_browser_ui.gypi                      |   5 +
  chrome/common/url_constants.cc                     |   3 +
  chrome/common/url_constants.h                      |   2 +
  tools/gritsettings/resource_ids                    |   2 +-
- 14 files changed, 428 insertions(+), 2 deletions(-)
+ 14 files changed, 429 insertions(+), 2 deletions(-)
  create mode 100644 chrome/browser/resources/file_picker/file_picker.css
  create mode 100644 chrome/browser/resources/file_picker/file_picker.html
  create mode 100644 chrome/browser/resources/file_picker/file_picker.js
@@ -33,10 +33,10 @@ File browsing UI will be added later.
  create mode 100644 chrome/browser/ui/webui/file_picker/file_picker_web_dialog.cc
 
 diff --git a/chrome/app/generated_resources.grd b/chrome/app/generated_resources.grd
-index 68fdfeb..7ace911 100644
+index 84f4c3d..18c0450 100644
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -4423,7 +4423,7 @@ Even if you have downloaded files from this website before, the website might ha
+@@ -4431,7 +4431,7 @@ Even if you have downloaded files from this website before, the website might ha
        </message>
  
        <message name="IDS_EXTENSION_PERMISSION_LINE" desc="Template for item in list of privileges that an extension or app has">
@@ -45,7 +45,7 @@ index 68fdfeb..7ace911 100644
        </message>
        <message name="IDS_EXTENSION_RATING_COUNT" desc="Number of ratings an app or extensions has (displayed after star icons)">
          (<ph name="RATING_COUNT">$1<ex>46</ex></ph>)
-@@ -15568,6 +15568,14 @@ Do you accept?
+@@ -15618,6 +15618,14 @@ After you create a new supervised user, you can manage their settings at any tim
          This option disables support in Cast Streaming for encoding video streams using platform hardware.
        </message>
  
@@ -61,10 +61,10 @@ index 68fdfeb..7ace911 100644
        <message name="IDS_HOTWORD_OPT_IN_CLOSE" desc="Label for the close button for the 'Ok Google' hotword opt-in dialog.">
          Close
 diff --git a/chrome/browser/browser_resources.grd b/chrome/browser/browser_resources.grd
-index acfff9b..5bf0bfe 100644
+index ec1dfab..f929131 100644
 --- a/chrome/browser/browser_resources.grd
 +++ b/chrome/browser/browser_resources.grd
-@@ -451,6 +451,9 @@
+@@ -452,6 +452,9 @@
        <if expr="enable_media_router">
          <part file="media_router_resources.grdp" />
        </if>
@@ -279,10 +279,10 @@ index 9e9476b..dccb14b 100644
  
  void ChromeBrowserMainExtraPartsAura::ToolkitInitialized() {
 diff --git a/chrome/browser/ui/webui/chrome_web_ui_controller_factory.cc b/chrome/browser/ui/webui/chrome_web_ui_controller_factory.cc
-index 023af7a..8d20ba0 100644
+index 4068212..5350433 100644
 --- a/chrome/browser/ui/webui/chrome_web_ui_controller_factory.cc
 +++ b/chrome/browser/ui/webui/chrome_web_ui_controller_factory.cc
-@@ -74,6 +74,8 @@
+@@ -72,6 +72,8 @@
  #include "ui/oobe/oobe_md_ui.h"
  #include "ui/web_dialogs/web_dialog_ui.h"
  #include "url/gurl.h"
@@ -291,7 +291,7 @@ index 023af7a..8d20ba0 100644
  
  #if !defined(DISABLE_NACL)
  #include "chrome/browser/ui/webui/nacl_ui.h"
-@@ -311,6 +313,8 @@ WebUIFactoryFunction GetWebUIFactoryFunction(WebUI* web_ui,
+@@ -316,6 +318,8 @@ WebUIFactoryFunction GetWebUIFactoryFunction(WebUI* web_ui,
      return &NewWebUI<DomainReliabilityInternalsUI>;
    if (url.host() == chrome::kChromeUIFlagsHost)
      return &NewWebUI<FlagsUI>;
@@ -553,10 +553,10 @@ index 0000000..87c3c9d
 +
 +}  // namespace ui
 diff --git a/chrome/chrome_browser_ui.gypi b/chrome/chrome_browser_ui.gypi
-index 4a506a7..148569a 100644
+index 116678f..63e9c54 100644
 --- a/chrome/chrome_browser_ui.gypi
 +++ b/chrome/chrome_browser_ui.gypi
-@@ -441,6 +441,9 @@
+@@ -443,6 +443,9 @@
        'browser/ui/webui/favicon_source.h',
        'browser/ui/webui/fileicon_source.cc',
        'browser/ui/webui/fileicon_source.h',
@@ -566,7 +566,15 @@ index 4a506a7..148569a 100644
        'browser/ui/webui/flags_ui.cc',
        'browser/ui/webui/flags_ui.h',
        'browser/ui/webui/gcm_internals_ui.cc',
-@@ -3073,6 +3076,7 @@
+@@ -2756,6 +2759,7 @@
+         '../content/content.gyp:content_browser',
+         '../content/content.gyp:content_common',
+         '../crypto/crypto.gyp:crypto',
++        '../ozone/ui/webui/webui.gypi:webui',
+         '../skia/skia.gyp:skia',
+         '../sync/sync.gyp:sync',
+         '../third_party/cacheinvalidation/cacheinvalidation.gyp:cacheinvalidation',
+@@ -3094,6 +3098,7 @@
                'dependencies': [
                  '../build/linux/system.gyp:dbus',
                  '../build/linux/system.gyp:fontconfig',
@@ -575,7 +583,7 @@ index 4a506a7..148569a 100644
                ],
              }],
 diff --git a/chrome/common/url_constants.cc b/chrome/common/url_constants.cc
-index 909de08..0b520ba 100644
+index 0ac097f..4cc8425 100644
 --- a/chrome/common/url_constants.cc
 +++ b/chrome/common/url_constants.cc
 @@ -48,6 +48,7 @@ const char kChromeUIExtensionsURL[] = "chrome://extensions/";
@@ -594,7 +602,7 @@ index 909de08..0b520ba 100644
  const char kChromeUIFlagsHost[] = "flags";
  const char kChromeUIFlashHost[] = "flash";
  const char kChromeUIGCMInternalsHost[] = "gcm-internals";
-@@ -594,6 +596,7 @@ const char* const kChromeHostURLs[] = {
+@@ -601,6 +603,7 @@ const char* const kChromeHostURLs[] = {
    kChromeUICreditsHost,
    kChromeUIDeviceLogHost,
    kChromeUIDNSHost,
@@ -603,7 +611,7 @@ index 909de08..0b520ba 100644
    kChromeUIHistoryHost,
    kChromeUIInvalidationsHost,
 diff --git a/chrome/common/url_constants.h b/chrome/common/url_constants.h
-index 5a2e486..0536c58 100644
+index 9162183..f5070bf 100644
 --- a/chrome/common/url_constants.h
 +++ b/chrome/common/url_constants.h
 @@ -43,6 +43,7 @@ extern const char kChromeUIExtensionsURL[];
@@ -623,7 +631,7 @@ index 5a2e486..0536c58 100644
  extern const char kChromeUIFlashHost[];
  extern const char kChromeUIGCMInternalsHost[];
 diff --git a/tools/gritsettings/resource_ids b/tools/gritsettings/resource_ids
-index a0c369d..939887c 100644
+index 6c353d2..a0f79f7 100644
 --- a/tools/gritsettings/resource_ids
 +++ b/tools/gritsettings/resource_ids
 @@ -16,7 +16,7 @@

--- a/ui/webui/webui.gypi
+++ b/ui/webui/webui.gypi
@@ -3,16 +3,21 @@
 # found in the LICENSE file.
 
 {
-  'dependencies': [
-    '<(DEPTH)/ui/base/ui_base.gyp:ui_base',
-    '<(DEPTH)/build/linux/system.gyp:pangocairo',
-    '../ui/accessibility/accessibility.gyp:accessibility'
-  ],
-  'sources': [
-    'file_picker_web_dialog.h',
-    'select_file_dialog_impl_webui.h',
-    'select_file_dialog_impl_webui.cc',
-    'ozone_webui.h',
-    'ozone_webui.cc'
-  ],
+  'targets': [
+    {
+      'target_name': 'webui',
+      'type': 'static_library',
+      'dependencies': [
+        '<(DEPTH)/ui/base/ui_base.gyp:ui_base',
+        '<(DEPTH)/build/linux/system.gyp:pangocairo',
+      ],
+      'sources': [
+        'file_picker_web_dialog.h',
+        'select_file_dialog_impl_webui.h',
+        'select_file_dialog_impl_webui.cc',
+        'ozone_webui.h',
+        'ozone_webui.cc'
+      ],
+    }
+  ]
 }


### PR DESCRIPTION
When using dynamic linking, BuildWebUI() cannot be linked.
This patch fixes this link problem.