### PR TITLE
Build Wayland and Weston using jhbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,33 @@ Instructions can be found here: https://github.com/otcshare/ozone-wayland/wiki
 ## License
 
 Ozone-Wayland's code uses the BSD license (check the LICENSE file in the project).
+
+# Tips
+## Build Wayland & Weston
+If you want to build and run ozone-wayland, you should install wayland and weston first.
+Here is the instruction using jhbuild.
+
+#### Install jhbuild
+Please refer to this instruction: https://developer.gnome.org/jhbuild/stable/getting-started.html.en
+
+#### Install dependent packages using apt-get
+```
+$ cd ~/chromium/src
+$ ozone/tools/jhbuild/install-dependencies
+```
+#### Build and install Wayland & Weston
+```
+$ cd ozone/tools/jhbuild
+$ jhbuild -f wayland.jhbuildrc
+```
+#### Run Weston
+```
+$ jhbuild -f wayland.jhbuildrc shell
+$ cd ~/chromium/src
+$ out/wayland/root/bin/weston --fullscreen
+```
+#### Run ozone-wayland in Weston
+Open a weston terminal
+```
+$ out/Release/chrome --no-sandbox
+```

--- a/tools/jhbuild/install-dependencies
+++ b/tools/jhbuild/install-dependencies
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# This script was originally implemented for the WebKitGtk+ project, but
+# it was updated for building Wayland & Weston and only tested on Ubuntu 14.04
+
+# This script needs to be run with root rights.
+if [ $UID -ne 0 ]; then
+    sudo $0
+    exit 0
+fi
+
+function printNotSupportedMessageAndExit() {
+    echo
+    echo "Currently this script only works for distributions supporting apt-get."
+    echo "Please add support for your distribution."
+    echo
+    exit 1
+}
+
+function checkInstaller {
+    # apt-get - Debian based distributions
+    apt-get --version &> /dev/null
+    if [ $? -eq 0 ]; then
+        installDependenciesWithApt
+        exit 0
+    fi
+
+    printNotSupportedMessageAndExit
+}
+
+function installDependenciesWithApt {
+    # These are dependencies necessary for building Wayland and Weston.
+    apt-get install \
+        libffi-dev \
+        doxygen \
+        xmlto \
+        libpciaccess-dev \
+        python-mako \
+        x11proto-dri3-dev \
+        x11proto-present-dev \
+        llvm libxcb-xkb-dev \
+        graphviz \
+        libxcb-composite0-dev \
+        libmtdev-dev \
+        libevdev-dev || true
+}
+
+checkInstaller
+

--- a/tools/jhbuild/wayland.jhbuildrc
+++ b/tools/jhbuild/wayland.jhbuildrc
@@ -1,0 +1,12 @@
+# -*- mode: python -*-
+
+import os
+
+use_local_modulesets = True
+moduleset = 'wayland.modules'
+modules = ['weston']
+checkoutroot = os.getcwd() + '/../../../out/wayland/source'
+prefix = os.getcwd() +'/../../../out/wayland/root'
+autogenargs=''
+
+os.environ['EGL_PLATFORM'] = 'wayland'

--- a/tools/jhbuild/wayland.modules
+++ b/tools/jhbuild/wayland.modules
@@ -1,0 +1,76 @@
+<?xml version="1.0"?><!--*- mode: nxml; indent-tabs-mode: nil -*-->
+<!DOCTYPE moduleset SYSTEM "moduleset.dtd">
+<?xml-stylesheet type="text/xsl" href="moduleset.xsl"?>
+<!-- vim:set ts=2 expandtab: -->
+<moduleset>
+  <repository type="git" name="freedesktop" default="yes"
+      href="git://anongit.freedesktop.org/git"/>
+  <repository type="git" name="wayland" default="yes"
+      href="git://anongit.freedesktop.org/git/wayland"/>
+  <repository type="git" name="mesa" default="yes"
+      href="git://anongit.freedesktop.org/git/mesa"/>
+  <repository type="git" name="xorg-proto" default="yes"
+      href="git://anongit.freedesktop.org/git/xorg/proto"/>
+  <repository type="git" name="github"
+      href="git://github.com/"/>
+  <repository type="git" name="gnu" default="yes"
+      href="git://git.sv.gnu.org"/>
+
+  <autotools id="pixman">
+    <branch repo="freedesktop" tag="cf086d4949092861dc3729465a3881d229cc1060"/>
+  </autotools>
+
+  <autotools id="cairo" autogenargs="--enable-gl --enable-xcb">
+    <branch repo="freedesktop" tag="8b798c320f6fd2d87349d0a716304474022bc5ea"/>
+    <dependencies>
+      <dep package="pixman"/>
+      <dep package="mesa"/>
+    </dependencies>
+  </autotools>
+
+  <autotools id="drm" autogenargs="--enable-nouveau-experimental-api">
+    <branch repo="mesa" tag="b2360626c4aa1dccdf3fe258b833121748d64d35"/>
+  </autotools>
+
+  <autotools id="mesa" skip-autogen="never" autogenargs="--enable-gles2 --disable-gallium-egl --with-egl-platforms=x11,wayland,drm --enable-gbm --enable-shared-glapi --with-gallium-drivers=r300,r600,swrast,nouveau">
+    <branch repo="mesa" tag="c696a318ef1eb58f65fb867d5616bbefd1def31e"/>
+    <dependencies>
+      <dep package="drm"/>
+      <dep package="glproto"/>
+    </dependencies>
+  </autotools>
+
+  <autotools id="wayland" autogenargs="--with-egl-platforms=wayland,drm,x11">
+    <branch repo="wayland" tag="d08c079739caa966350ce9fb8b620f8a69dfb05f"/>
+    <dependencies>
+      <dep package="libunwind"/>
+    </dependencies>
+  </autotools>
+
+  <autotools id="weston" autogenargs="--disable-setuid-install">
+    <branch repo="wayland" tag="0c944b07c451212bd287e79985a99333b8d4c368"/>
+    <dependencies>
+      <dep package="cairo"/>
+      <dep package="wayland"/>
+      <dep package="libinput"/>
+      <dep package="libxkbcommon"/>
+    </dependencies>
+  </autotools>
+
+  <autotools id="libunwind">
+    <branch repo="gnu" tag="6e3254ea6e6fa6c433cd38f9716a0b3b4110de64"/>
+  </autotools>
+
+  <autotools id="glproto" >
+    <branch repo="xorg-proto" tag="bd3d751e1eb17efb39f65093271bb4ac071aa9e0"/>
+  </autotools>
+
+  <autotools id="libxkbcommon" autogenargs="--with-xkb-config-root=/usr/share/X11/xkb">
+    <branch repo="github" module="xkbcommon/libxkbcommon.git" tag="8e1fed6c68ca23d8a6f31c30e36417f4c07274b1"/>
+  </autotools>
+
+  <autotools id="libinput">
+    <branch repo="wayland" tag="12000e737e5f57180826c8178aa291b8706db6bc"/>
+  </autotools>
+
+</moduleset>


### PR DESCRIPTION
This CL adds jbhuild build environment to build Wayland and Weston
easily. Refer to the following instruction for more details:
https://github.com/01org/ozone-wayland/wiki/Build-Wayland-&-Weston-using-jhbuild

Currently, it was only tested on Ubuntu 14.04.