### PR TITLE
tools/jhbuild: moduleset requires the full path

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,6 @@
 Alexis Menard <alexis.menard@intel.com>
 Andriy Prystupa <prand007@gmail.com>
+Carlos Alberto Lopez Perez <clopez@igalia.com>
 Changbin Shao <changbin.shao@intel.com>
 Daniel Narvaez <dwnarvaez@gmail.com>
 Dongseong Hwang <dongseong.hwang@intel.com>

--- a/tools/jhbuild/wayland.jhbuildrc
+++ b/tools/jhbuild/wayland.jhbuildrc
@@ -3,7 +3,7 @@
 import os
 
 use_local_modulesets = True
-moduleset = 'wayland.modules'
+moduleset = os.getcwd() + '/wayland.modules'
 modules = ['weston']
 checkoutroot = os.getcwd() + '/../../../out/wayland/source'
 prefix = os.getcwd() +'/../../../out/wayland/root'


### PR DESCRIPTION
After following the instructions of the README for building weston with jhbuild:

    $ cd ozone/tools/jhbuild
    $ jhbuild -f wayland.jhbuildrc
    W: modulesets directory (/build/jhbuild-qmq7p2/jhbuild-3.5.91/modulesets) not found, disabling use_local_modulesets
    jhbuild build: could not download http://git.gnome.org/browse/jhbuild/plain/modulesets    /wayland.modules.modules: HTTP Error 404: Not found


It seems that JHBuild requires the full path to find the local moduleset.
The attached patch fixes the problem.