### PR TITLE
Add an error message when running with software rendering

### DIFF
--- a/wayland/display.cc
+++ b/wayland/display.cc
@@ -35,6 +35,7 @@
 #include "ozone/wayland/shell/shell.h"
 #include "ozone/wayland/window.h"
 #include "ui/ozone/public/native_pixmap.h"
+#include "ui/ozone/public/surface_ozone_canvas.h"
 
 #if defined(ENABLE_DRM_SUPPORT)
 namespace {
@@ -238,6 +239,24 @@ scoped_refptr<ui::NativePixmap> WaylandDisplay::CreateNativePixmap(
 #else
   return SurfaceFactoryOzone::CreateNativePixmap(widget, size, format, usage);
 #endif
+}
+
+scoped_ptr<ui::SurfaceOzoneCanvas> WaylandDisplay::CreateCanvasForWidget(
+    gfx::AcceleratedWidget widget) {
+  LOG(FATAL) << "The browser process has attempted to start the GPU process in "
+             << "software rendering mode. Software rendering is not supported "
+             << "in Ozone-Wayland, so this is fatal. Usually this error occurs "
+             << "because the GPU process crashed too many times in hardware "
+             << "rendering mode. To debug the GPU process, start Chrome with "
+             << "--gpu-startup-dialog so that the GPU process pauses on "
+             << "startup, then attach to it with 'gdb -p' and run the command "
+             << "'signal SIGUSR1' in order to unpause it. If you have xterm "
+             << "then you can also run 'chrome --no-sandbox "
+             << "--gpu-launcher='xterm -title renderer -e gdb "
+             << "--eval-command=run --args''";
+
+  // This code will obviously never be reached, but it placates -Wreturn-type.
+  return scoped_ptr<ui::SurfaceOzoneCanvas>();
 }
 
 void WaylandDisplay::SetWidgetState(unsigned w,

--- a/wayland/display.h
+++ b/wayland/display.h
@@ -102,6 +102,9 @@ class WaylandDisplay : public ui::WindowStateChangeHandler,
       gfx::AcceleratedWidget widget, gfx::Size size, BufferFormat format,
           BufferUsage usage) override;
 
+  scoped_ptr<ui::SurfaceOzoneCanvas> CreateCanvasForWidget(
+      gfx::AcceleratedWidget widget) override;
+
   // WindowStateChangeHandler implementation:
   void SetWidgetState(unsigned widget,
                       ui::WidgetState state) override;


### PR DESCRIPTION
If the GPU process is started in software rendering mode, it's almost
always because it has crashed too many times in hardware rendering mode.
Leave a helpful error message for new developers, since this commonly
occurs when building Ozone-Wayland for new devices or when hacking on
the GPU process, and it can take a while to figure out what's going on
if you haven't seen it before.