### PR TITLE
Make Milestone-Jefferson work with M44 again.

### DIFF
--- a/patches/patch-chromium.sh
+++ b/patches/patch-chromium.sh
@@ -3,7 +3,7 @@
 PATCH_DIR=`pwd`/src/ozone/patches/
 HACKING_BRANCH=master-ozone
 HACKING_OZONE_BRANCH=master-ozonewayland
-RELEASE_BRANCH=45.0.2421.0
+RELEASE_BRANCH=44.0.2403.107
 
 echo "Ozone-Wayland: patching Chromium"
 cd src/

--- a/platform/ozone_platform_wayland.cc
+++ b/platform/ozone_platform_wayland.cc
@@ -23,7 +23,6 @@
 #include "ui/ozone/common/native_display_delegate_ozone.h"
 #include "ui/ozone/platform/drm/host/drm_cursor.h"
 #include "ui/ozone/platform/drm/host/drm_gpu_platform_support_host.h"
-#include "ui/ozone/platform/drm/host/drm_overlay_manager.h"
 #include "ui/ozone/platform/drm/host/drm_window_host_manager.h"
 #include "ui/ozone/public/ozone_platform.h"
 #include "ui/ozone/public/system_input_injector.h"
@@ -54,10 +53,6 @@ class OzonePlatformWayland : public OzonePlatform {
   CursorFactoryOzone* GetCursorFactoryOzone() override {
     return cursor_factory_ozone_.get();
   }
-
-  ui::OverlayManagerOzone* GetOverlayManager() override {
-    return overlay_manager_.get();
-  } 
 
   InputController* GetInputController() override {
     return NULL;
@@ -101,7 +96,6 @@ class OzonePlatformWayland : public OzonePlatform {
         new ui::InputMethodContextFactoryWayland());
 #endif
     cursor_factory_ozone_.reset(new ui::CursorFactoryOzoneWayland());
-    overlay_manager_.reset(new DrmOverlayManager(false));
     KeyboardLayoutEngineManager::SetKeyboardLayoutEngine(make_scoped_ptr(
         new XkbKeyboardLayoutEngine(xkb_evdev_code_converter_)));
     event_factory_ozone_.reset(
@@ -146,7 +140,6 @@ class OzonePlatformWayland : public OzonePlatform {
   scoped_ptr<ui::OzoneChannel> gpu_platform_;
   scoped_ptr<ui::RemoteStateChangeHandler> state_change_handler_;
   scoped_ptr<ozonewayland::WaylandDisplay> wayland_display_;
-  scoped_ptr<DrmOverlayManager> overlay_manager_;
   XkbEvdevCodes xkb_evdev_code_converter_;
   DISALLOW_COPY_AND_ASSIGN(OzonePlatformWayland);
 };

--- a/wayland/egl/surface_ozone_wayland.cc
+++ b/wayland/egl/surface_ozone_wayland.cc
@@ -36,7 +36,7 @@ bool SurfaceOzoneWayland::OnSwapBuffers() {
 }
 
 bool SurfaceOzoneWayland::OnSwapBuffersAsync(
-    const ui::SwapCompletionCallback& callback) {
+    const SwapCompletionCallback& callback) {
   return true;
 }
 

--- a/wayland/egl/surface_ozone_wayland.h
+++ b/wayland/egl/surface_ozone_wayland.h
@@ -22,7 +22,7 @@ class SurfaceOzoneWayland : public ui::SurfaceOzoneEGL {
   intptr_t GetNativeWindow() override;
   bool ResizeNativeWindow(const gfx::Size& viewport_size) override;
   bool OnSwapBuffers() override;
-  bool OnSwapBuffersAsync(const ui::SwapCompletionCallback& callback) override;
+  bool OnSwapBuffersAsync(const SwapCompletionCallback& callback) override;
   scoped_ptr<gfx::VSyncProvider> CreateVSyncProvider() override;
 
  private:


### PR DESCRIPTION
This patch set reverts a few changes that went into the branch and broke the build, as the respective upstream changes are not part of M44.

Fixes #374.