### PR TITLE
[WIP] Add initial support for paste

### DIFF
--- a/patches/0008-PlatformWindow-Add-needed-support-in-PlatformWindow.patch
+++ b/patches/0008-PlatformWindow-Add-needed-support-in-PlatformWindow.patch
@@ -6,8 +6,8 @@ Subject: [PATCH] Add needed support in PlatformWindow.
 This patch adds necessary API support in PlatformWindow. The changes
 need to be evaluated further before trying to upstream them.
 ---
- ui/platform_window/platform_window.h | 20 ++++++++++++++++++++
- 1 file changed, 20 insertions(+)
+ ui/platform_window/platform_window.h | 38 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 38 insertions(+)
 
 diff --git a/ui/platform_window/platform_window.h b/ui/platform_window/platform_window.h
 index 67d3206..a063cfd 100644
@@ -15,22 +15,22 @@ index 67d3206..a063cfd 100644
 +++ b/ui/platform_window/platform_window.h
 @@ -6,12 +6,16 @@
  #define UI_PLATFORM_WINDOW_PLATFORM_WINDOW_H_
- 
+
  #include "base/memory/scoped_ptr.h"
 +#include "base/strings/string16.h"
 +#include "third_party/skia/include/core/SkPath.h"
  #include "ui/base/cursor/cursor.h"
- 
+
  namespace gfx {
  class Rect;
  }
- 
+
 +class SkPath;
 +
  namespace ui {
- 
+
  class PlatformImeController;
-@@ -23,8 +27,24 @@ class PlatformWindowDelegate;
+@@ -23,8 +25,40 @@ class PlatformWindowDelegate;
  // underlying platform windowing system (i.e. X11/Win/OSX).
  class PlatformWindow {
   public:
@@ -45,16 +45,32 @@ index 67d3206..a063cfd 100644
 +  };
 +
    virtual ~PlatformWindow() {}
- 
+
 +  virtual void InitPlatformWindow(PlatformWindowType type,
 +                                  gfx::AcceleratedWidget parent_window) { }
 +  virtual void SetWidgetTitle(const base::string16& title) { }
 +  virtual void SetWindowShape(const SkPath& path) { }
 +  virtual void SetOpacity(unsigned char opacity) { }
 +
++  // Asks the GPU process to send data of type |mime_type|.
++  virtual void RequestDragData(const std::string& mime_type) { }
++  virtual void RequestSelectionData(const std::string& mime_type) { }
++
++  // Indicates to the drag source that the data will or will not be accepted
++  // at the current (x, y) coordinates. Note that there is a harmless race here.
++  // The browser process could decide to accept or reject the data based on
++  // old (x, y) coordinates that have since been updated by a new DragMotion
++  // event in the GPU process. This doesn't matter because the browser process
++  // will promptly correct the matter by calling one of these functions again
++  // when it receives the DragMotion event, and these functions are only used to
++  // provide user feedback: they don't affect correctness.
++  virtual void DragWillBeAccepted(uint32_t serial,
++                                  const std::string& mime_type) { }
++  virtual void DragWillBeRejected(uint32_t serial) { }
++
    virtual void Show() = 0;
    virtual void Hide() = 0;
    virtual void Close() = 0;
--- 
-1.9.1
+--
+2.4.3
 

--- a/patches/0018-Add-drag-and-drop-interfaces-to-PlatformWindowDelega.patch
+++ b/patches/0018-Add-drag-and-drop-interfaces-to-PlatformWindowDelega.patch
@@ -1,0 +1,48 @@
+From 5c333c821fe28f263f3b4d9d40f8df7cb416549b Mon Sep 17 00:00:00 2001
+From: Michael Catanzaro <mcatanzaro@igalia.com>
+Date: Mon, 13 Jul 2015 19:46:39 -0500
+Subject: [PATCH] Add drag-and-drop interfaces to PlatformWindowDelegate
+
+Based on a patch by Kalyan Kondapally
+---
+ ui/platform_window/platform_window_delegate.h | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/ui/platform_window/platform_window_delegate.h b/ui/platform_window/platform_window_delegate.h
+index 67c63a7..18162a5 100644
+--- a/ui/platform_window/platform_window_delegate.h
++++ b/ui/platform_window/platform_window_delegate.h
+@@ -7,6 +7,8 @@
+
+ #include "ui/gfx/native_widget_types.h"
+
++#include <vector>
++
+ namespace gfx {
+ class Rect;
+ }
+@@ -47,6 +49,22 @@ class PlatformWindowDelegate {
+                                             float device_pixel_ratio) = 0;
+
+   virtual void OnActivationChanged(bool active) = 0;
++
++  virtual void OnDragEnter(unsigned windowhandle,
++                           float x,
++                           float y,
++                           const std::vector<std::string>& mime_types,
++                           uint32_t serial) { }
++
++  virtual void OnDragDataReceived(int fd) { }
++
++  virtual void OnDragLeave() { }
++
++  virtual void OnDragMotion(float x,
++                            float y,
++                            uint32_t time) { }
++
++  virtual void OnDragDrop() { }
+ };
+
+ }  // namespace ui
+--
+2.4.3

--- a/patches/0019-Add-clipboard-support-for-Wayland.patch
+++ b/patches/0019-Add-clipboard-support-for-Wayland.patch
@@ -1,0 +1,231 @@
+From b77062379dacb88fdd6a057876eb2d7349ba1ebd Mon Sep 17 00:00:00 2001
+From: Michael Catanzaro <mcatanzaro@igalia.com>
+Date: Mon, 14 Sep 2015 11:05:38 -0500
+Subject: [PATCH] Add clipboard support for Wayland
+
+Hopefully the actual ClipboardWayland class could be moved into the
+Ozone-Wayland codebase, so it doesn't have to live in a
+difficult-to-modify patch. But gyp is hard and I haven't figured out how
+to do this.
+---
+ ui/base/clipboard/clipboard_aura.cc    |  9 ++++
+ ui/base/clipboard/clipboard_aura.h     |  2 +-
+ ui/base/clipboard/clipboard_wayland.cc | 88 ++++++++++++++++++++++++++++++++++
+ ui/base/clipboard/clipboard_wayland.h  | 48 +++++++++++++++++++
+ ui/base/ui_base.gyp                    |  3 ++
+ 5 files changed, 149 insertions(+), 1 deletion(-)
+ create mode 100644 ui/base/clipboard/clipboard_wayland.cc
+ create mode 100644 ui/base/clipboard/clipboard_wayland.h
+
+diff --git a/ui/base/clipboard/clipboard_aura.cc b/ui/base/clipboard/clipboard_aura.cc
+index e682392..148ffa6 100644
+--- a/ui/base/clipboard/clipboard_aura.cc
++++ b/ui/base/clipboard/clipboard_aura.cc
+@@ -16,6 +16,11 @@
+ #include "ui/base/clipboard/custom_data_helper.h"
+ #include "ui/gfx/geometry/size.h"
+ 
++#if defined(USE_OZONE) && USE_OZONE
++#include "ui/base/clipboard/clipboard_wayland.h"
++#include "ui/ozone/platform_selection.h"
++#endif
++
+ namespace ui {
+ 
+ namespace {
+@@ -513,6 +518,10 @@ const Clipboard::FormatType& Clipboard::GetPepperCustomDataFormatType() {
+ 
+ // Clipboard factory method.
+ Clipboard* Clipboard::Create() {
++#if defined(USE_OZONE) && USE_OZONE
++  if (!strcmp(GetOzonePlatformName(), "wayland"))
++    return new ClipboardWayland;
++#endif
+   return new ClipboardAura;
+ }
+ 
+diff --git a/ui/base/clipboard/clipboard_aura.h b/ui/base/clipboard/clipboard_aura.h
+index e5fbc34..d50a7f4 100644
+--- a/ui/base/clipboard/clipboard_aura.h
++++ b/ui/base/clipboard/clipboard_aura.h
+@@ -10,7 +10,7 @@
+ namespace ui {
+ 
+ class ClipboardAura : public Clipboard {
+- private:
++ protected:
+   friend class Clipboard;
+ 
+   ClipboardAura();
+diff --git a/ui/base/clipboard/clipboard_wayland.cc b/ui/base/clipboard/clipboard_wayland.cc
+new file mode 100644
+index 0000000..b21fe74
+--- /dev/null
++++ b/ui/base/clipboard/clipboard_wayland.cc
+@@ -0,0 +1,88 @@
++// Copyright (c) 2015 Igalia S.L.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "ui/base/clipboard/clipboard_wayland.h"
++
++namespace ui {
++
++// Implementation Note:
++//
++// ClipboardAura is designed to be the clipboard manager for ChromeOS. That's
++// overkill for our purposes, since in Wayland the compositor plays the role of
++// the clipboard manager. But it is exactly what we need to serve as a proxy for
++// the clipboard in the browser process. We don't want it to manage a stack of
++// clipboard history, though, so we clear the clipboard before writing new data.
++// TODO(mcatanzaro): Decide if clearing the clipboard history before each write
++// is really necessary. It's probably harmless to keep old history.
++//
++// Note that CLIPBOARD_TYPE_COPY_PASTE is the only supported clipboard type.
++// In particular, Wayland does not have any equivalent to the PRIMARY selection
++// (CLIPBOARD_TYPE_SELECTION), to the dismay of middle-click paste lovers.
++
++ClipboardWayland::ClipboardWayland() {
++}
++
++ClipboardWayland::~ClipboardWayland() {
++}
++
++void ClipboardWayland::Clear(ClipboardType type) {
++  ClipboardAura::Clear(type);
++}
++
++void ClipboardWayland::Clear() {
++  Clear(CLIPBOARD_TYPE_COPY_PASTE);
++}
++
++void ClipboardWayland::WriteObjects(ClipboardType type,
++                                    const ObjectMap& objects) {
++  Clear();
++  ClipboardAura::WriteObjects(type, objects);
++}
++
++void ClipboardWayland::WriteText(const char* text_data, size_t text_len) {
++ Clear();
++ ClipboardAura::WriteText(text_data, text_len);
++}
++
++void ClipboardWayland::WriteHTML(const char* markup_data,
++                                 size_t markup_len,
++                                 const char* url_data,
++                                 size_t url_len) {
++  Clear();
++  ClipboardAura::WriteHTML(markup_data, markup_len, url_data, url_len);
++}
++
++void ClipboardWayland::WriteRTF(const char* rtf_data, size_t data_len) {
++  Clear();
++  ClipboardAura::WriteRTF(rtf_data, data_len);
++}
++
++void ClipboardWayland::WriteBookmark(const char* title_data,
++                                     size_t title_len,
++                                     const char* url_data,
++                                     size_t url_len) {
++  Clear();
++  ClipboardAura::WriteBookmark(title_data, title_len, url_data, url_len);
++}
++
++void ClipboardWayland::WriteWebSmartPaste() {
++  // TODO(mcatanzaro): Figure out what this is supposed to do. Is it working
++  // properly, or is it broken by all the calls to Clear()?
++  Clear();
++  ClipboardAura::WriteWebSmartPaste();
++}
++
++void ClipboardWayland::WriteBitmap(const SkBitmap& bitmap) {
++  Clear();
++  ClipboardAura::WriteBitmap(bitmap);
++}
++
++void ClipboardWayland::WriteData(const FormatType& format,
++                                 const char* data_data,
++                                 size_t data_len) {
++  Clear();
++  ClipboardAura::WriteData(format, data_data, data_len);
++}
++
++}  // namespace ui
+diff --git a/ui/base/clipboard/clipboard_wayland.h b/ui/base/clipboard/clipboard_wayland.h
+new file mode 100644
+index 0000000..7747217
+--- /dev/null
++++ b/ui/base/clipboard/clipboard_wayland.h
+@@ -0,0 +1,48 @@
++// Copyright 2015 Igalia S.L.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef OZONE_UI_BASE_CLIPBOARD_CLIPBOARD_WAYLAND_H_
++#define OZONE_UI_BASE_CLIPBOARD_CLIPBOARD_WAYLAND_H_
++
++#include "ui/base/clipboard/clipboard_aura.h"
++
++#include "base/memory/scoped_ptr.h"
++
++namespace ui {
++
++class ClipboardWayland : public ClipboardAura {
++ public:
++  void Clear();
++
++ private:
++  friend class Clipboard;
++
++  ClipboardWayland();
++  ~ClipboardWayland() override;
++
++  void Clear(ClipboardType type) override;
++
++  void WriteObjects(ClipboardType type, const ObjectMap& objects) override;
++  void WriteText(const char* text_data, size_t text_len) override;
++  void WriteHTML(const char* markup_data,
++                 size_t markup_len,
++                 const char* url_data,
++                 size_t url_len) override;
++  void WriteRTF(const char* rtf_data, size_t data_len) override;
++  void WriteBookmark(const char* title_data,
++                     size_t title_len,
++                     const char* url_data,
++                     size_t url_len) override;
++  void WriteWebSmartPaste() override;
++  void WriteBitmap(const SkBitmap& bitmap) override;
++  void WriteData(const FormatType& format,
++                 const char* data_data,
++                 size_t data_len) override;
++
++  DISALLOW_COPY_AND_ASSIGN(ClipboardWayland);
++};
++
++}  // namespace ui
++
++#endif  // OZONE_UI_BASE_CLIPBOARD_CLIPBOARD_WAYLAND_H_
+diff --git a/ui/base/ui_base.gyp b/ui/base/ui_base.gyp
+index 36f07f7..cd1bd62 100644
+--- a/ui/base/ui_base.gyp
++++ b/ui/base/ui_base.gyp
+@@ -68,6 +68,8 @@
+         'clipboard/clipboard_types.h',
+         'clipboard/clipboard_util_win.cc',
+         'clipboard/clipboard_util_win.h',
++        'clipboard/clipboard_wayland.cc',
++        'clipboard/clipboard_wayland.h',
+         'clipboard/clipboard_win.cc',
+         'clipboard/clipboard_win.h',
+         'clipboard/custom_data_helper.cc',
+@@ -453,6 +455,7 @@
+         ['OS=="win" or use_clipboard_aurax11==1', {
+           'sources!': [
+             'clipboard/clipboard_aura.cc',
++            'clipboard/clipboard_wayland.cc',
+           ],
+         }, {
+           'sources!': [
+-- 
+2.4.3
+

--- a/platform/messages.h
+++ b/platform/messages.h
@@ -140,6 +140,16 @@ IPC_MESSAGE_CONTROL4(WaylandInput_DragMotion,  // NOLINT(readability/fn_size)
 IPC_MESSAGE_CONTROL1(WaylandInput_DragDrop,  // NOLINT(readability/fn_size)
                      unsigned /* window handle */)
 
+IPC_MESSAGE_CONTROL1(  // NOLINT(readability/fn_size)
+    WaylandInput_SelectionChanged,
+    std::vector<std::string> /* mime_types */)
+
+IPC_MESSAGE_CONTROL1(WaylandInput_SelectionData,  // NOLINT(readability/fn_size)
+                     base::FileDescriptor /* pipefd */)
+
+IPC_MESSAGE_CONTROL0(WaylandInput_SelectionCleared)  // NOLINT(readability/
+                                                     //        fn_size)
+
 //------------------------------------------------------------------------------
 // GPU Messages
 // These messages are from the Browser to the GPU process.

--- a/platform/messages.h
+++ b/platform/messages.h
@@ -117,6 +117,29 @@ IPC_MESSAGE_CONTROL0(WaylandInput_PreeditEnd)  // NOLINT(readability/fn_size)
 
 IPC_MESSAGE_CONTROL0(WaylandInput_PreeditStart)  // NOLINT(readability/fn_size)
 
+IPC_MESSAGE_CONTROL5(WaylandInput_DragEnter,  // NOLINT(readability/fn_size)
+                     unsigned /* window handle */,
+                     float /* x */,
+                     float /* y */,
+                     std::vector<std::string> /* mime_types */,
+                     uint32_t /* serial */)
+
+IPC_MESSAGE_CONTROL2(WaylandInput_DragData,  // NOLINT(readability/fn_size)
+                     unsigned /* window handle */,
+                     base::FileDescriptor /* pipefd */)
+
+IPC_MESSAGE_CONTROL1(WaylandInput_DragLeave,  // NOLINT(readability/fn_size)
+                     unsigned /* window handle */)
+
+IPC_MESSAGE_CONTROL4(WaylandInput_DragMotion,  // NOLINT(readability/fn_size)
+                     unsigned /* window handle */,
+                     float /* x */,
+                     float /* y */,
+                     uint32_t /* time */)
+
+IPC_MESSAGE_CONTROL1(WaylandInput_DragDrop,  // NOLINT(readability/fn_size)
+                     unsigned /* window handle */)
+
 //------------------------------------------------------------------------------
 // GPU Messages
 // These messages are from the Browser to the GPU process.
@@ -170,3 +193,17 @@ IPC_MESSAGE_CONTROL0(WaylandDisplay_ShowInputPanel)  // NOLINT(readability/
 
 IPC_MESSAGE_CONTROL0(WaylandDisplay_HideInputPanel)  // NOLINT(readability/
                                                      //         fn_size)
+
+IPC_MESSAGE_CONTROL1(WaylandDisplay_RequestDragData,  // NOLINT(readability/
+                     std::string /* mime_type */)     //        fn_size)
+
+IPC_MESSAGE_CONTROL1(  // NOLINT(readability/fn_size)
+    WaylandDisplay_RequestSelectionData,
+    std::string /* mime_type */)
+
+IPC_MESSAGE_CONTROL2(WaylandDisplay_DragWillBeAccepted,  // NOLINT(readability/
+                     uint32_t /* serial */,              //        fn_size)
+                     std::string /* mime_type */)
+
+IPC_MESSAGE_CONTROL1(WaylandDisplay_DragWillBeRejected,  // NOLINT(readability/
+                     uint32_t /* serial */)              //        fn_size)

--- a/platform/ozone_wayland_window.cc
+++ b/platform/ozone_wayland_window.cc
@@ -113,6 +113,23 @@ void OzoneWaylandWindow::SetOpacity(unsigned char opacity) {
   }
 }
 
+void OzoneWaylandWindow::RequestDragData(const std::string& mime_type) {
+  sender_->Send(new WaylandDisplay_RequestDragData(mime_type));
+}
+
+void OzoneWaylandWindow::RequestSelectionData(const std::string& mime_type) {
+  sender_->Send(new WaylandDisplay_RequestSelectionData(mime_type));
+}
+
+void OzoneWaylandWindow::DragWillBeAccepted(uint32_t serial,
+                                            const std::string& mime_type) {
+  sender_->Send(new WaylandDisplay_DragWillBeAccepted(serial, mime_type));
+}
+
+void OzoneWaylandWindow::DragWillBeRejected(uint32_t serial) {
+  sender_->Send(new WaylandDisplay_DragWillBeRejected(serial));
+}
+
 gfx::Rect OzoneWaylandWindow::GetBounds() {
   return bounds_;
 }

--- a/platform/ozone_wayland_window.h
+++ b/platform/ozone_wayland_window.h
@@ -5,6 +5,7 @@
 #ifndef OZONE_PLATFORM_OZONE_WAYLAND_WINDOW_H_
 #define OZONE_PLATFORM_OZONE_WAYLAND_WINDOW_H_
 
+#include <string>
 #include "base/memory/ref_counted.h"
 #include "ozone/platform/window_constants.h"
 #include "third_party/skia/include/core/SkRegion.h"
@@ -40,6 +41,11 @@ class OzoneWaylandWindow : public PlatformWindow,
   void SetWidgetTitle(const base::string16& title) override;
   void SetWindowShape(const SkPath& path) override;
   void SetOpacity(unsigned char opacity) override;
+  void RequestDragData(const std::string& mime_type) override;
+  void RequestSelectionData(const std::string& mime_type) override;
+  void DragWillBeAccepted(uint32_t serial,
+                          const std::string& mime_type) override;
+  void DragWillBeRejected(uint32_t serial) override;
   gfx::Rect GetBounds() override;
   void SetBounds(const gfx::Rect& bounds) override;
   void Show() override;

--- a/platform/window_manager_wayland.h
+++ b/platform/window_manager_wayland.h
@@ -114,6 +114,16 @@ class WindowManagerWayland
   void WindowDeActivated(unsigned windowhandle);
   void WindowActivated(unsigned windowhandle);
 
+  void DragEnter(unsigned windowhandle,
+                 float x,
+                 float y,
+                 const std::vector<std::string>& mime_types,
+                 uint32_t serial);
+  void DragData(unsigned windowhandle, base::FileDescriptor pipefd);
+  void DragLeave(unsigned windowhandle);
+  void DragMotion(unsigned windowhandle, float x, float y, uint32_t time);
+  void DragDrop(unsigned windowhandle);
+
   void InitializeXKB(base::SharedMemoryHandle fd, uint32_t size);
   // PlatformEventSource:
   void OnDispatcherListChanged() override;
@@ -147,6 +157,16 @@ class WindowManagerWayland
                         uint32_t time_stamp);
   void NotifyOutputSizeChanged(unsigned width,
                                unsigned height);
+
+  void NotifyDragEnter(unsigned windowhandle,
+                       float x,
+                       float y,
+                       const std::vector<std::string>& mime_types,
+                       uint32_t serial);
+  void NotifyDragData(unsigned windowhandle, base::FileDescriptor pipefd);
+  void NotifyDragLeave(unsigned windowhandle);
+  void NotifyDragMotion(unsigned windowhandle, float x, float y, uint32_t time);
+  void NotifyDragDrop(unsigned windowhandle);
 
   // List of all open aura::Window.
   std::list<OzoneWaylandWindow*>* open_windows_;

--- a/platform/window_manager_wayland.h
+++ b/platform/window_manager_wayland.h
@@ -123,6 +123,9 @@ class WindowManagerWayland
   void DragLeave(unsigned windowhandle);
   void DragMotion(unsigned windowhandle, float x, float y, uint32_t time);
   void DragDrop(unsigned windowhandle);
+  void SelectionChanged(const std::vector<std::string>& mime_types);
+  void SelectionData(base::FileDescriptor pipefd);
+  void SelectionCleared();
 
   void InitializeXKB(base::SharedMemoryHandle fd, uint32_t size);
   // PlatformEventSource:
@@ -167,6 +170,9 @@ class WindowManagerWayland
   void NotifyDragLeave(unsigned windowhandle);
   void NotifyDragMotion(unsigned windowhandle, float x, float y, uint32_t time);
   void NotifyDragDrop(unsigned windowhandle);
+  void NotifySelectionChanged(const std::vector<std::string>& mime_types);
+  void NotifySelectionData(base::FileDescriptor pipefd);
+  void NotifySelectionCleared();
 
   // List of all open aura::Window.
   std::list<OzoneWaylandWindow*>* open_windows_;

--- a/ui/desktop_aura/desktop_drag_drop_client_wayland.cc
+++ b/ui/desktop_aura/desktop_drag_drop_client_wayland.cc
@@ -4,14 +4,227 @@
 
 #include "ozone/ui/desktop_aura/desktop_drag_drop_client_wayland.h"
 
+#include <algorithm>
+#include <iterator>
+
+#include "base/files/file_path.h"
+#include "base/strings/string16.h"
+#include "base/strings/string_split.h"
+#include "base/strings/utf_string_conversions.h"
+#include "base/threading/thread_restrictions.h"
+#include "content/public/browser/browser_thread.h"
+#include "ui/aura/window.h"
+#include "ui/aura/window_tree_host.h"
+#include "ui/base/clipboard/clipboard.h"
 #include "ui/base/dragdrop/drag_drop_types.h"
 #include "ui/base/dragdrop/drop_target_event.h"
+#include "ui/base/dragdrop/file_info.h"
+#include "ui/base/dragdrop/os_exchange_data_provider_aura.h"
+#include "ui/platform_window/platform_window.h"
+
+// TODO(mcatanzaro): Add support for accepting drags from GTK+ and Qt.
+// Currently, only drags from the reference weston-dnd client are supported.
+//
+// We will need changes in both Wayland and GTK+ to support drags from GTK+.
+//
+// See: https://bugs.freedesktop.org/show_bug.cgi?id=91944
+//
+// Also relevant: https://bugs.freedesktop.org/show_bug.cgi?id=91945
+//
+// I have not tested Qt yet.
+
+// TODO(mcatanzaro): Add support for drags originating from Chrome. Currently,
+// only drags into Chrome from another process are supported.
 
 namespace views {
 
+namespace {
+
+auto& kMimeTypeText = ui::Clipboard::kMimeTypeText;
+auto& kMimeTypeURIList = ui::Clipboard::kMimeTypeURIList;
+
+const char kMimeTypeTextUTF8[] = "text/plain;charset=utf-8";
+
+void AddStringToOSExchangeData(ui::OSExchangeData* os_exchange_data,
+                               const std::string& data) {
+  if (data.empty())
+    return;
+
+  base::string16 string16 = base::UTF8ToUTF16(data);
+  os_exchange_data->SetString(string16);
+
+  VLOG(1) << "Added string " << string16 << " to OSExchangeData";
+}
+
+void AddURIListToOSExchangeData(ui::OSExchangeData* os_exchange_data,
+                                const std::string& data) {
+  std::vector<std::string> filenames = base::SplitString(
+      data,
+      "\n",
+      base::TRIM_WHITESPACE,
+      base::SPLIT_WANT_NONEMPTY);
+
+  // The URI list is allowed to contain comments, which need to be removed.
+  auto new_end = std::remove_if(filenames.begin(), filenames.end(),
+                                [](const std::string& value) {
+                                    return value.empty() || value[0] == '#';
+                                });
+  filenames.erase(new_end, filenames.end());
+
+  if (filenames.empty())
+    return;
+
+  std::vector<ui::FileInfo> file_infos;
+  for (std::string& filename : filenames) {
+    ui::FileInfo file;
+    file.path = base::FilePath::FromUTF8Unsafe(filename);
+    file_infos.push_back(file);
+    VLOG(1) << "Adding filename " << filename << " to OSExchangeData";
+  }
+
+  os_exchange_data->SetFilenames(file_infos);
+}
+
+void AddToOSExchangeData(ui::OSExchangeData* os_exchange_data,
+                         const std::string& data,
+                         const std::string& mime_type) {
+  VLOG(2) <<  __FUNCTION__ << " data=" << data << " mime_type=" << mime_type;
+
+  if ((mime_type == kMimeTypeText || mime_type == kMimeTypeTextUTF8)) {
+    DCHECK(!os_exchange_data->HasString());
+    AddStringToOSExchangeData(os_exchange_data, data);
+    return;
+  }
+
+  if (mime_type == kMimeTypeURIList) {
+    DCHECK(!os_exchange_data->HasFile());
+    AddURIListToOSExchangeData(os_exchange_data, data);
+    return;
+  }
+
+  NOTREACHED();
+}
+
+}  // namespace
+
+DesktopDragDropClientWayland::DragDataCollector::DragDataCollector(
+    base::WeakPtr<DesktopDragDropClientWayland> drag_drop_client,
+    const std::vector<std::string>& mime_types,
+    int windowhandle)
+    : drag_drop_client_(drag_drop_client),
+      os_exchange_data_(new ui::OSExchangeDataProviderAura),
+      windowhandle_(windowhandle) {
+  std::copy(mime_types.begin(),
+            mime_types.end(),
+            std::insert_iterator<std::list<std::string>>(
+                unprocessed_mime_types_,
+                unprocessed_mime_types_.begin()));
+}
+
+DesktopDragDropClientWayland::DragDataCollector::~DragDataCollector() {
+  if (pipefd_)
+    close(pipefd_);
+}
+
+void DesktopDragDropClientWayland::DragDataCollector::SetPipeFd(int pipefd) {
+  DCHECK(!IsReadingData());
+  pipefd_ = pipefd;
+}
+
+bool DesktopDragDropClientWayland::DragDataCollector::IsReadingData() const {
+  return !!pipefd_;
+}
+
+void DesktopDragDropClientWayland::DragDataCollector::HandleNextMimeType() {
+  DCHECK(!IsReadingData());
+
+  if (!drag_drop_client_)
+    return;
+
+  std::string mime_type = SelectNextMimeType();
+  if (!mime_type.empty()) {
+    VLOG(1) << __FUNCTION__ << ": requesting data of MIME type " << mime_type;
+    drag_drop_client_->platform_window_.RequestDragData(mime_type);
+  } else {
+    drag_drop_client_->OnDragDataCollected(this);
+  }
+}
+
+// static
+void DesktopDragDropClientWayland::DragDataCollector::ReadDragData(
+    scoped_refptr<DragDataCollector> data_collector) {
+  VLOG(1) <<  __FUNCTION__ << " data_collector=" << data_collector.get();
+
+  base::ThreadRestrictions::AssertIOAllowed();
+
+  ssize_t bytes_read;
+  std::string data;
+  for (;;) {
+    char buffer[PIPE_BUF + 1];
+    bytes_read = HANDLE_EINTR(read(data_collector->GetPipeFd(),
+                                   buffer,
+                                   sizeof(buffer) - 1));
+    if (bytes_read == 0)
+      break;
+    if (bytes_read == -1)
+      break;
+    buffer[bytes_read] = '\0';
+    data += buffer;
+  }
+  close(data_collector->pipefd_);
+  data_collector->pipefd_ = 0;
+
+  DCHECK(!data_collector->unprocessed_mime_types_.empty());
+
+  if (!data.empty()) {
+    AddToOSExchangeData(&data_collector->os_exchange_data_,
+                        data,
+                        data_collector->unprocessed_mime_types_.front());
+
+    if (data_collector->first_received_mime_type_.empty()) {
+      data_collector->first_received_mime_type_ =
+          data_collector->unprocessed_mime_types_.front();
+    }
+  }
+
+  data_collector->unprocessed_mime_types_.erase(
+      data_collector->unprocessed_mime_types_.begin());
+
+  content::BrowserThread::PostTask(
+      content::BrowserThread::UI,
+      FROM_HERE,
+      base::Bind(
+          &DesktopDragDropClientWayland::DragDataCollector::HandleNextMimeType,
+          data_collector.get()->AsWeakPtr()));
+}
+
+std::string
+DesktopDragDropClientWayland::DragDataCollector::SelectNextMimeType() {
+  // unprocessed_mime_types_ is a list instead of a vector to avoid repeatedly
+  // reallocating a vector when removing its first element in here. The
+  // performance impact would normally be insignificant, but it might matter if
+  // a malicious Wayland client offers a huge list of MIME types. We don't want
+  // to start from the last element of the list so as to prefer MIME types that
+  // occur earlier in the list.
+  while (!unprocessed_mime_types_.empty()) {
+    std::string& mime_type = unprocessed_mime_types_.front();
+    if (((mime_type == kMimeTypeText || mime_type == kMimeTypeTextUTF8) &&
+         !os_exchange_data_.HasString()) ||
+        (mime_type == kMimeTypeURIList && !os_exchange_data_.HasFile()))  {
+      return mime_type;
+    }
+    unprocessed_mime_types_.erase(unprocessed_mime_types_.begin());
+  }
+  return std::string();
+}
+
 DesktopDragDropClientWayland::DesktopDragDropClientWayland(
-    aura::Window* root_window) {
-  NOTIMPLEMENTED();
+    aura::Window* root_window, ui::PlatformWindow* platform_window)
+    : root_window_(*root_window),
+      platform_window_(*platform_window),
+      target_window_(nullptr),
+      delegate_(nullptr),
+      weak_ptr_factory_(this) {
 }
 
 DesktopDragDropClientWayland::~DesktopDragDropClientWayland() {
@@ -43,7 +256,252 @@ void DesktopDragDropClientWayland::DragCancel() {
 }
 
 bool DesktopDragDropClientWayland::IsDragDropInProgress() {
-  return false;
+  return !!windowhandle_;
+}
+
+void DesktopDragDropClientWayland::OnWindowDestroying(aura::Window* window) {
+  DCHECK_EQ(target_window_, window);
+  target_window_->RemoveObserver(this);
+  target_window_ = nullptr;
+}
+
+void DesktopDragDropClientWayland::OnDragEnter(
+    unsigned windowhandle,
+    float x,
+    float y,
+    const std::vector<std::string>& mime_types,
+    uint32_t serial) {
+  VLOG(1) <<  __FUNCTION__ << " windowhandle=" << windowhandle
+           << " x=" << x << " y=" << y << " serial=" << serial;
+
+  if (data_collector_) {
+      // A previous drag ended before drag data was fully transferred, then this
+      // new drag started. Cancel the old drag before proceeding.
+      DragDropSessionCompleted();
+  }
+
+  if (windowhandle_) {
+      LOG(ERROR) << "Received DragEnter event during an outstanding drag.";
+      return;
+  }
+
+  if (!windowhandle || mime_types.empty()) {
+    LOG(ERROR) << "Received invalid DragEnter event from GPU process.";
+    return;
+  }
+
+  point_.SetPoint(x, y);
+
+  serial_ = serial;
+  windowhandle_ = windowhandle;
+
+  data_collector_ = new DragDataCollector(weak_ptr_factory_.GetWeakPtr(),
+                                          mime_types,
+                                          windowhandle);
+  data_collector_->HandleNextMimeType();
+
+  // From here on out, it's unsafe to modify the DragDataCollector from the
+  // browser thread until the DragDataCollector calls OnDragDataCollected.
+}
+
+void DesktopDragDropClientWayland::OnDragDataReceived(int pipefd) {
+  VLOG(1) <<  __FUNCTION__ << " pipefd=" << pipefd;
+
+  if (!data_collector_) {
+    // OnDragLeave has already been called.
+    close(pipefd);
+    return;
+  }
+
+  if (data_collector_->IsReadingData()) {
+    LOG(ERROR) << "Received DragData event during an outstanding read.";
+    close(pipefd);
+    return;
+  }
+
+  data_collector_->SetPipeFd(pipefd);
+  content::BrowserThread::PostTask(
+      content::BrowserThread::FILE_USER_BLOCKING,
+      FROM_HERE,
+      base::Bind(&DesktopDragDropClientWayland::DragDataCollector::ReadDragData,
+                 data_collector_));
+}
+
+void DesktopDragDropClientWayland::OnDragLeave() {
+  VLOG(1) <<  __FUNCTION__;
+
+  // Wayland sends OnDragLeave after OnDragDrop, but the DragDropDelegate
+  // expects to receive only one or the other.
+  if (delegate_ && should_emit_drag_exited_)
+    delegate_->OnDragExited();
+
+  should_emit_drag_exited_ = true;
+
+  if (!delayed_drop_target_event_) {
+    DragDropSessionCompleted();
+  }
+
+  // TODO(mcatanzaro): It would be nice to support cancellation of the previous
+  // DragDataCollector's tasks. Otherwise, it's just going to keep on
+  // reading data until it finishes, blocking its thread. But this probably
+  // doesn't matter much, since the reading will usually be pretty fast.
+}
+
+void DesktopDragDropClientWayland::OnDragMotion(float x,
+                                                float y,
+                                                uint32_t time) {
+  VLOG(2) << __FUNCTION__ << " x=" << x << " y=" << y << " time=" << time;
+
+  point_.SetPoint(x, y);
+
+  if (!delegate_)
+    return;
+
+  scoped_ptr<ui::DropTargetEvent> event = CreateDropTargetEvent();
+  if (event) {
+    bool shouldAcceptDrag = delegate_->OnDragUpdated(*event);
+
+    if (shouldAcceptDrag && !did_most_recently_accept_drag_)
+       IndicateDragWillBeAccepted();
+    else if (!shouldAcceptDrag && did_most_recently_accept_drag_)
+       IndicateDragWillBeRejected();
+  }
+}
+
+void DesktopDragDropClientWayland::OnDragDrop() {
+  VLOG(1) <<  __FUNCTION__;
+
+  scoped_ptr<ui::DropTargetEvent> event = CreateDropTargetEvent();
+
+  if (event) {
+    if (delegate_) {
+      // All the drag data is available. This is the usual case.
+      delegate_->OnPerformDrop(*event);
+      should_emit_drag_exited_ = false;
+    } else {
+      // Unlikely case: the drop could occur before all the drag data has been
+      // transferred from the source process. If so, we must delay the emission
+      // of the drop event until the data is available. This is straightforward,
+      // but some caution is required to not touch the DragDataCollector, which
+      // is being modified by the other thread!
+      delayed_drop_target_event_ = event.Pass();
+    }
+  }
+}
+
+void DesktopDragDropClientWayland::IndicateDragWillBeAccepted() {
+  DCHECK(serial_);
+  DCHECK(data_collector_);
+  DCHECK(!data_collector_->first_received_mime_type().empty());
+
+  // TODO(mcatanzaro): https://bugs.freedesktop.org/show_bug.cgi?id=91950
+  // It is impossible to know which MIME type to accept, since DragDropDelegate
+  // does not provide this information. Since this won't affect the
+  // correctness of the drag (it is only to allow the source client to show a
+  // type-dependent cursor), we just send the first MIME type that we received
+  // data for. It would be better if Wayland would provide a way to indicate
+  // acceptance without specifying MIME type.
+  platform_window_.DragWillBeAccepted(
+      serial_,
+      data_collector_->first_received_mime_type());
+
+  did_most_recently_accept_drag_ = true;
+}
+
+void DesktopDragDropClientWayland::IndicateDragWillBeRejected() {
+  DCHECK(serial_);
+  platform_window_.DragWillBeRejected(serial_);
+
+  did_most_recently_accept_drag_ = false;
+}
+
+void DesktopDragDropClientWayland::OnDragDataCollected(
+    DragDataCollector* collector) {
+  VLOG(1) <<  __FUNCTION__ << " collector=" << collector;
+
+  // Make sure the drag has not already been cancelled. If it has been
+  // cancelled, then |data_collector_| will have been reset by OnDragLeave()
+  // and will not match |collector|.
+  if (data_collector_ != collector)
+    return;
+
+  // Did the other process actually send data?
+  if (collector->first_received_mime_type().empty()) {
+    IndicateDragWillBeRejected();
+    return;
+  }
+
+  gfx::Point root_location(point_.x(), point_.y());
+  root_window_.GetHost()->ConvertPointFromNativeScreen(&root_location);
+
+  target_window_ = root_window_.GetEventHandlerForPoint(root_location);
+  if (!target_window_)
+    return;
+
+  target_window_->AddObserver(this);
+
+  delegate_ = aura::client::GetDragDropDelegate(target_window_);
+  if (!delegate_)
+    return;
+
+  scoped_ptr<ui::DropTargetEvent> event = CreateDropTargetEvent();
+  if (event) {
+    VLOG(1) << "Sending OnDragEntered to DragDropDelegate";
+    delegate_->OnDragEntered(*event);
+    delegate_->OnDragUpdated(*event) ?
+        IndicateDragWillBeAccepted() : IndicateDragWillBeRejected();
+
+    // The drop has already occurred, and should be reported immediately. In
+    // this case, the coordinates reported for the drop are actually from an
+    // earlier point in time than the coordinates reported for the drag enter,
+    // which is weird, but harmless: it's only important that the drop occur at
+    // the right place.
+    if (delayed_drop_target_event_) {
+      delegate_->OnPerformDrop(*delayed_drop_target_event_.get());
+      DragDropSessionCompleted();
+    }
+  }
+}
+
+scoped_ptr<ui::DropTargetEvent>
+DesktopDragDropClientWayland::CreateDropTargetEvent() const {
+  if (!target_window_)
+    return nullptr;
+
+  gfx::Point root_location(point_.x(), point_.y());
+  root_window_.GetHost()->ConvertPointFromNativeScreen(&root_location);
+
+  // TODO(mcatanzaro): The Wayland drag-and-drop protocol is not yet
+  // sufficiently advanced to allow specifying drag actions (move/copy/link),
+  // so we have no choice but to hardcode one drag action here. WIP code at:
+  // http://lists.freedesktop.org/archives/wayland-devel/2015-June/022517.html
+  int drag_operations = ui::DragDropTypes::DRAG_COPY;
+
+  gfx::Point target_location = root_location;
+  target_window_->GetHost()->ConvertPointToHost(&target_location);
+  aura::Window::ConvertPointToTarget(&root_window_,
+                                     target_window_,
+                                     &target_location);
+
+  // Caution: this function can be called before the DragDataCollector has
+  // finished receiving drag data, so it's unsafe to do pretty much anything
+  // with it. Taking the address of its OSExchangeData, which can't be changed,
+  // is harmless, though.
+  return scoped_ptr<ui::DropTargetEvent>(new ui::DropTargetEvent(
+      data_collector_->GetData(),
+      target_location,
+      root_location,
+      drag_operations));
+}
+
+void DesktopDragDropClientWayland::DragDropSessionCompleted() {
+  serial_ = 0;
+  windowhandle_ = 0;
+  data_collector_ = nullptr;
+  if (target_window_) {
+    target_window_->RemoveObserver(this);
+    target_window_ = nullptr;
+  }
 }
 
 }  // namespace views

--- a/ui/desktop_aura/desktop_drag_drop_client_wayland.h
+++ b/ui/desktop_aura/desktop_drag_drop_client_wayland.h
@@ -5,16 +5,34 @@
 #ifndef OZONE_IMPL_DESKTOP_AURA_DESKTOP_DRAG_DROP_CLIENT_WAYLAND_H_
 #define OZONE_IMPL_DESKTOP_AURA_DESKTOP_DRAG_DROP_CLIENT_WAYLAND_H_
 
-#include "base/compiler_specific.h"
+#include <list>
+#include <string>
+#include <vector>
+
+#include "base/memory/ref_counted.h"
+#include "base/memory/scoped_ptr.h"
+#include "base/memory/weak_ptr.h"
+#include "ui/aura/window_observer.h"
+#include "ui/base/dragdrop/os_exchange_data.h"
+#include "ui/gfx/geometry/point.h"
 #include "ui/views/views_export.h"
 #include "ui/wm/public/drag_drop_client.h"
+#include "ui/wm/public/drag_drop_delegate.h"
+
+namespace ui {
+
+class PlatformWindow;
+
+}
 
 namespace views {
 
 class VIEWS_EXPORT DesktopDragDropClientWayland
-    : public aura::client::DragDropClient {
+    : public aura::client::DragDropClient,
+      public aura::WindowObserver {
  public:
-  explicit DesktopDragDropClientWayland(aura::Window* root_window);
+  explicit DesktopDragDropClientWayland(aura::Window* root_window,
+                                        ui::PlatformWindow* platform_window);
   ~DesktopDragDropClientWayland() override;
 
   // Overridden from aura::client::DragDropClient:
@@ -31,7 +49,137 @@ class VIEWS_EXPORT DesktopDragDropClientWayland
   void DragCancel() override;
   bool IsDragDropInProgress() override;
 
+  // Overridden from void aura::WindowObserver:
+  void OnWindowDestroying(aura::Window* window) override;
+
+  // Events received via IPC from the WaylandDataSource in the GPU process.
+  void OnDragEnter(unsigned windowhandle,
+                   float x,
+                   float y,
+                   const std::vector<std::string>& mime_types,
+                   uint32_t serial);
+  void OnDragDataReceived(int pipefd);
+  void OnDragLeave();
+  void OnDragMotion(float x, float y, uint32_t time);
+  void OnDragDrop();
+
  private:
+  // Used to build up an OSExchangeDataProvider and pass it to the
+  // DragDropDelegate of the target window. This requires round-tripping between
+  // the browser process and the GPU process once for each type of data to be
+  // stored in the OSExchangeDataProvider. The GPU process will pass us a file
+  // descriptor to read the data from, then once the read has completed we will
+  // close the descriptor and indicate to the GPU process that it is safe to
+  // request the next file descriptor. This has to happen one-by-one because
+  // some Wayland clients (e.g. GTK+ applications) expect that after calling
+  // wl_data_offer_receive() (in the GPU process), we will drain the received
+  // file descriptor of all data and close it before calling
+  // wl_data_offer_receive() again. We could read from the pipe either
+  // asynchronously in the IO thread, or synchronously in the user-blocking file
+  // thread. The file thread was chosen for simplicity. Either way, a
+  // RefCountedThreadSafe container is required, since there is a very small
+  // window in which a DesktopDragDropClientWayland could theoretically be
+  // destroyed in the middle of an ongoing drag operation, and the drag could be
+  // cancelled before all data has been received. Note also that a
+  // DragDataCollector corresponds to exactly one outstanding drag-and-drop
+  // and should not be reused for a second drag-and-drop session.
+  class DragDataCollector
+      : public base::RefCountedThreadSafe<DragDataCollector>,
+        public base::SupportsWeakPtr<DragDataCollector> {
+   public:
+    DragDataCollector(
+        base::WeakPtr<DesktopDragDropClientWayland> drag_drop_client,
+        const std::vector<std::string>& mime_types,
+        int windowhandle);
+    // DragDropDataController assumes ownership of |pipefd| and will ensure it
+    // is closed exactly once.
+    void SetPipeFd(int pipefd);
+    int GetPipeFd() const { return pipefd_; }
+
+    std::string first_received_mime_type() const {
+      return first_received_mime_type_;
+    }
+
+    bool IsReadingData() const;
+    void HandleNextMimeType();
+
+    const ui::OSExchangeData& GetData() const { return os_exchange_data_; }
+
+    // Synchronously read drag-and-drop data from the source process.
+    static void ReadDragData(scoped_refptr<DragDataCollector>);
+   private:
+    friend class base::RefCountedThreadSafe<DragDataCollector>;
+    ~DragDataCollector();
+
+    // Returns the next MIME type to be received from the source process, or an
+    // empty string if there are no more interesting MIME types left to process.
+    std::string SelectNextMimeType();
+
+    base::WeakPtr<DesktopDragDropClientWayland> drag_drop_client_;
+    ui::OSExchangeData os_exchange_data_;
+    std::list<std::string> unprocessed_mime_types_;
+    std::string first_received_mime_type_;
+    int windowhandle_;
+    int pipefd_ = 0;
+  };
+
+ public:
+  // Called by the DragDataCollector when all drag data has been received.
+  void OnDragDataCollected(DragDataCollector* collector);
+
+ private:
+  // Returns a DropTargetEvent to be passed to the DragDropDelegate, or null to
+  // abort the drag.
+  scoped_ptr<ui::DropTargetEvent> CreateDropTargetEvent() const;
+
+  void DragDropSessionCompleted();
+
+  // Use to provide feedback to the source process on whether the drag will be
+  // accepted for the current coordinates and available mime types. This might
+  // be used to change the cursor, for example.
+  void IndicateDragWillBeAccepted();
+  void IndicateDragWillBeRejected();
+
+  // Valid between the start of a drag operation and when the process of reading
+  // drag-and-drop data from the source process has completed. No drag events
+  // can be sent to the DragDropDelegate until all data has been collected.
+  scoped_refptr<DragDataCollector> data_collector_;
+
+  // Unique identifier for the current drag.
+  uint32_t serial_ = 0;
+
+  // Window handle for active drag, or 0 if there is no active drag.
+  unsigned windowhandle_ = 0;
+
+  aura::Window& root_window_;
+  ui::PlatformWindow& platform_window_;
+
+  // Null unless all drag data has been received and the drag is unfinished.
+  aura::Window* target_window_;
+
+  // The most recent native coordinates of a drag.
+  gfx::Point point_;
+
+  // This is the interface that allows us to send drag events from Ozone-Wayland
+  // to the cross-platform code.
+  aura::client::DragDropDelegate* delegate_;
+
+  // The Wayland sends a drag leave event after a drag drop event, but the
+  // DragDropDelegate expects only one or the other. This is set to false after
+  // a successful drop to indicate that the drag leave event should not be
+  // passed on to the DragDropDelegate.
+  bool should_emit_drag_exited_ = true;
+
+  // Used to keep track of whether IndicateDragWillBeAccepted or
+  // IndicateDragWillBeRejected was most-recently called.
+  bool did_most_recently_accept_drag_ = false;
+
+  // Null except when a drop has occured but drag data is still being read.
+  // Caution: it's unsafe to use the OSExchangeData on the UI thread!
+  scoped_ptr<ui::DropTargetEvent> delayed_drop_target_event_;
+
+  base::WeakPtrFactory<DesktopDragDropClientWayland> weak_ptr_factory_;
+
   DISALLOW_COPY_AND_ASSIGN(DesktopDragDropClientWayland);
 };
 

--- a/ui/desktop_aura/desktop_window_tree_host_ozone.cc
+++ b/ui/desktop_aura/desktop_window_tree_host_ozone.cc
@@ -170,7 +170,8 @@ DesktopWindowTreeHostOzone::CreateTooltip() {
 scoped_ptr<aura::client::DragDropClient>
 DesktopWindowTreeHostOzone::CreateDragDropClient(
     DesktopNativeCursorManager* cursor_manager) {
-  drag_drop_client_ = new DesktopDragDropClientWayland(window());
+  drag_drop_client_ = new DesktopDragDropClientWayland(window(),
+                                                       platform_window_.get());
   return make_scoped_ptr(drag_drop_client_);
 }
 
@@ -742,6 +743,40 @@ void DesktopWindowTreeHostOzone::OnActivationChanged(bool active) {
 
   desktop_native_widget_aura_->HandleActivationChanged(active);
   native_widget_delegate_->AsWidget()->GetRootView()->SchedulePaint();
+}
+
+void DesktopWindowTreeHostOzone::OnDragEnter(
+    unsigned windowhandle,
+    float x,
+    float y,
+    const std::vector<std::string>& mime_types,
+    uint32_t serial) {
+  if (drag_drop_client_)
+    drag_drop_client_->OnDragEnter(windowhandle, x, y, mime_types, serial);
+}
+
+void DesktopWindowTreeHostOzone::OnDragDataReceived(int fd) {
+  if (drag_drop_client_)
+    drag_drop_client_->OnDragDataReceived(fd);
+  else
+    close(fd);
+}
+
+void DesktopWindowTreeHostOzone::OnDragLeave() {
+  if (drag_drop_client_)
+    drag_drop_client_->OnDragLeave();
+}
+
+void DesktopWindowTreeHostOzone::OnDragMotion(float x,
+                                              float y,
+                                              uint32_t time) {
+  if (drag_drop_client_)
+    drag_drop_client_->OnDragMotion(x, y, time);
+}
+
+void DesktopWindowTreeHostOzone::OnDragDrop() {
+  if (drag_drop_client_)
+    drag_drop_client_->OnDragDrop();
 }
 
 void DesktopWindowTreeHostOzone::OnLostCapture() {

--- a/ui/desktop_aura/desktop_window_tree_host_ozone.h
+++ b/ui/desktop_aura/desktop_window_tree_host_ozone.h
@@ -145,8 +145,17 @@ class VIEWS_EXPORT DesktopWindowTreeHostOzone
   void OnWindowStateChanged(ui::PlatformWindowState new_state) override;
   void OnLostCapture() override;
   void OnAcceleratedWidgetAvailable(gfx::AcceleratedWidget widget,
-                                     float device_pixel_ratio) override;
+                                    float device_pixel_ratio) override;
   void OnActivationChanged(bool active) override;
+  void OnDragEnter(unsigned windowhandle,
+                   float x,
+                   float y,
+                   const std::vector<std::string>& mime_types,
+                   uint32_t serial) override;
+  void OnDragDataReceived(int fd) override;
+  void OnDragLeave() override;
+  void OnDragMotion(float x, float y, uint32_t time) override;
+  void OnDragDrop() override;
 
  private:
   enum {

--- a/wayland/data_device.cc
+++ b/wayland/data_device.cc
@@ -1,0 +1,139 @@
+// Copyright 2015 Igalia S.L.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ozone/wayland/data_device.h"
+
+#include "ozone/wayland/data_offer.h"
+#include "ozone/wayland/display.h"
+
+namespace ozonewayland {
+
+WaylandDataDevice::WaylandDataDevice(WaylandDisplay* display, wl_seat* seat)
+    : data_device_(*wl_data_device_manager_get_data_device(
+                       display->GetDataDeviceManager(), seat)),
+      display_(*display),
+      drag_offer_(nullptr),
+      window_(nullptr),
+      selection_offer_(nullptr) {
+  static const struct wl_data_device_listener kDataDeviceListener = {
+    WaylandDataDevice::OnDataOffer,
+    WaylandDataDevice::OnEnter,
+    WaylandDataDevice::OnLeave,
+    WaylandDataDevice::OnMotion,
+    WaylandDataDevice::OnDrop,
+    WaylandDataDevice::OnSelection
+  };
+  wl_data_device_add_listener(&data_device_, &kDataDeviceListener, this);
+}
+
+WaylandDataDevice::~WaylandDataDevice() {
+  wl_data_device_destroy(&data_device_);
+}
+
+void WaylandDataDevice::RequestDragData(const std::string& mime_type) {
+  if (drag_offer_) {
+    DCHECK(window_);
+    int pipefd = drag_offer_->Receive(mime_type);
+    display_.DragData(window_->Handle(), {pipefd, true});
+  }
+}
+
+void WaylandDataDevice::RequestSelectionData(const std::string& mime_type) {
+  NOTIMPLEMENTED();
+}
+
+void WaylandDataDevice::DragWillBeAccepted(uint32_t serial,
+                                           const std::string& mime_type) {
+  if (drag_offer_)
+    drag_offer_->Accept(serial, mime_type);
+}
+
+void WaylandDataDevice::DragWillBeRejected(uint32_t serial) {
+  if (drag_offer_)
+    drag_offer_->Reject(serial);
+}
+
+// static
+void WaylandDataDevice::OnDataOffer(void* data,
+                                    wl_data_device* data_device,
+                                    wl_data_offer* id) {
+  auto self = static_cast<WaylandDataDevice*>(data);
+
+  DCHECK(!self->new_offer_);
+  self->new_offer_.reset(new WaylandDataOffer(id));
+}
+
+// static
+void WaylandDataDevice::OnEnter(void* data,
+                                wl_data_device* data_device,
+                                uint32_t serial,
+                                wl_surface* surface,
+                                wl_fixed_t x,
+                                wl_fixed_t y,
+                                wl_data_offer* id) {
+  auto self = static_cast<WaylandDataDevice*>(data);
+
+  DCHECK(self->new_offer_);
+  DCHECK(!self->drag_offer_);
+  self->drag_offer_ = self->new_offer_.Pass();
+
+  DCHECK(!self->window_);
+  self->window_ = static_cast<WaylandWindow*>(
+      wl_surface_get_user_data(surface));
+
+  self->display_.DragEnter(self->window_->Handle(),
+                           wl_fixed_to_double(x),
+                           wl_fixed_to_double(y),
+                           self->drag_offer_->GetAvailableMimeTypes(),
+                           serial);
+}
+
+// static
+void WaylandDataDevice::OnLeave(void* data, wl_data_device* data_device) {
+  auto self = static_cast<WaylandDataDevice*>(data);
+  self->display_.DragLeave(self->window_->Handle());
+  self->drag_offer_.reset();
+  self->window_ = nullptr;
+}
+
+// static
+void WaylandDataDevice::OnMotion(void* data,
+                                 wl_data_device* data_device,
+                                 uint32_t time,
+                                 wl_fixed_t x,
+                                 wl_fixed_t y) {
+  auto self = static_cast<WaylandDataDevice*>(data);
+  self->display_.DragMotion(self->window_->Handle(),
+                            wl_fixed_to_double(x),
+                            wl_fixed_to_double(y),
+                            time);
+}
+
+// static
+void WaylandDataDevice::OnDrop(void* data, wl_data_device* data_device) {
+  auto self = static_cast<WaylandDataDevice*>(data);
+  self->display_.DragDrop(self->window_->Handle());
+}
+
+// static
+void WaylandDataDevice::OnSelection(void* data,
+                                    wl_data_device* data_device,
+                                    wl_data_offer* id) {
+  auto self = static_cast<WaylandDataDevice*>(data);
+
+  // id will be null to indicate that the selection is no longer valid, i.e.
+  // there is no longer clipboard data available to paste.
+  if (!id) {
+    self->selection_offer_.reset();
+    return;
+  }
+
+  DCHECK(self->new_offer_);
+  self->selection_offer_ = self->new_offer_.Pass();
+
+  // TODO(mcatanzaro): Get the selection data to the browser process.
+  NOTIMPLEMENTED();
+}
+
+}  // namespace ozonewayland

--- a/wayland/data_device.cc
+++ b/wayland/data_device.cc
@@ -40,7 +40,10 @@ void WaylandDataDevice::RequestDragData(const std::string& mime_type) {
 }
 
 void WaylandDataDevice::RequestSelectionData(const std::string& mime_type) {
-  NOTIMPLEMENTED();
+  if (selection_offer_) {
+    int pipefd = selection_offer_->Receive(mime_type);
+    display_.SelectionData({pipefd, true});
+  }
 }
 
 void WaylandDataDevice::DragWillBeAccepted(uint32_t serial,
@@ -126,14 +129,15 @@ void WaylandDataDevice::OnSelection(void* data,
   // there is no longer clipboard data available to paste.
   if (!id) {
     self->selection_offer_.reset();
+    self->display_.SelectionCleared();
     return;
   }
 
   DCHECK(self->new_offer_);
   self->selection_offer_ = self->new_offer_.Pass();
 
-  // TODO(mcatanzaro): Get the selection data to the browser process.
-  NOTIMPLEMENTED();
+  self->display_.SelectionChanged(
+      self->selection_offer_->GetAvailableMimeTypes());
 }
 
 }  // namespace ozonewayland

--- a/wayland/data_device.h
+++ b/wayland/data_device.h
@@ -1,0 +1,82 @@
+// Copyright 2015 Igalia S.L.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef OZONE_WAYLAND_DATA_DEVICE_H_
+#define OZONE_WAYLAND_DATA_DEVICE_H_
+
+#include <wayland-client.h>
+#include <string>
+#include "base/basictypes.h"
+#include "base/memory/scoped_ptr.h"
+#include "ozone/wayland/window.h"
+
+namespace ozonewayland {
+
+class WaylandDataOffer;
+class WaylandDisplay;
+
+// This class handles copy-and-paste and drag-and-drop in the GPU process.
+class WaylandDataDevice {
+ public:
+  WaylandDataDevice(WaylandDisplay* display, wl_seat* input_seat);
+  ~WaylandDataDevice();
+
+  // DataExchangeHandler implementation
+  void RequestDragData(const std::string& mime_type);
+  void RequestSelectionData(const std::string& mime_type);
+  void DragWillBeAccepted(uint32_t serial, const std::string& mime_type);
+  void DragWillBeRejected(uint32_t serial);
+
+ private:
+  // wl_data_device_listener callbacks
+  static void OnDataOffer(void* data,
+                          wl_data_device* data_device,
+                          wl_data_offer* id);
+  static void OnEnter(void* data,
+                      wl_data_device* data_device,
+                      uint32_t serial,
+                      wl_surface* surface,
+                      wl_fixed_t x,
+                      wl_fixed_t y,
+                      wl_data_offer* id);
+  static void OnLeave(void* data, wl_data_device* data_device);
+  static void OnMotion(void* data,
+                       wl_data_device* data_device,
+                       uint32_t time,
+                       wl_fixed_t x,
+                       wl_fixed_t y);
+  static void OnDrop(void* data, wl_data_device* data_device);
+  static void OnSelection(void* data,
+                          wl_data_device* data_device,
+                          wl_data_offer* id);
+
+  // The wl_data_device wrapped by this WaylandDataDevice.
+  wl_data_device& data_device_;
+
+  // Used to dispatch events to the browser process.
+  WaylandDisplay& display_;
+
+  // There are two separate data offers at a time, the drag offer and the
+  // selection offer, each with independent lifetimes. When we receive a new
+  // offer, it is not immediately possible to know whether the new offer is the
+  // drag offer or the selection offer. This variable is used to store ownership
+  // of new data offers temporarily until its identity becomes known.
+  scoped_ptr<WaylandDataOffer> new_offer_;
+
+  // Offer to receive data from another process via drag-and-drop, or null if no
+  // drag-and-drop from another process is in progress.
+  scoped_ptr<WaylandDataOffer> drag_offer_;
+  // Window corresponding to |drag_offer_|, null if |drag_offer_| is null.
+  WaylandWindow* window_;
+
+  // Offer that holds the most-recent clipboard selection, or null if no
+  // clipboard data is available.
+  scoped_ptr<WaylandDataOffer> selection_offer_;
+
+  DISALLOW_COPY_AND_ASSIGN(WaylandDataDevice);
+};
+
+}  // namespace ozonewayland
+
+#endif  // OZONE_WAYLAND_DATA_DEVICE_H_

--- a/wayland/data_offer.cc
+++ b/wayland/data_offer.cc
@@ -1,0 +1,57 @@
+// Copyright 2015 Igalia S.L.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ozone/wayland/data_offer.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <cerrno>
+#include <cstring>
+
+#include "base/logging.h"
+
+namespace ozonewayland {
+
+WaylandDataOffer::WaylandDataOffer(wl_data_offer* data_offer)
+    : data_offer_(*data_offer) {
+  static const struct wl_data_offer_listener kDataOfferListener = {
+    WaylandDataOffer::OnOffer
+  };
+  wl_data_offer_add_listener(data_offer, &kDataOfferListener, this);
+}
+
+WaylandDataOffer::~WaylandDataOffer() {
+  wl_data_offer_destroy(&data_offer_);
+}
+
+void WaylandDataOffer::Accept(uint32_t serial, const std::string& mime_type) {
+  wl_data_offer_accept(&data_offer_, serial, mime_type.data());
+}
+
+void WaylandDataOffer::Reject(uint32_t serial) {
+  // Passing a null MIME type means "reject."
+  wl_data_offer_accept(&data_offer_, serial, nullptr);
+}
+
+int WaylandDataOffer::Receive(const std::string& mime_type) {
+  int pipefd[2];
+  if (pipe2(pipefd, O_CLOEXEC) == -1) {
+    LOG(ERROR) << "Failed to create pipe: " << strerror(errno);
+    return -1;
+  }
+
+  wl_data_offer_receive(&data_offer_, mime_type.data(), pipefd[1]);
+  close(pipefd[1]);
+  return pipefd[0];
+}
+
+// static
+void WaylandDataOffer::OnOffer(void* data,
+                               wl_data_offer* data_offer,
+                               const char* mime_type) {
+  auto self = static_cast<WaylandDataOffer*>(data);
+  self->mime_types_.push_back(mime_type);
+}
+
+}  // namespace ozonewayland

--- a/wayland/data_offer.h
+++ b/wayland/data_offer.h
@@ -1,0 +1,52 @@
+// Copyright 2015 Igalia S.L.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef OZONE_WAYLAND_DATA_OFFER_H_
+#define OZONE_WAYLAND_DATA_OFFER_H_
+
+#include <wayland-client.h>
+#include <string>
+#include <vector>
+
+#include "base/basictypes.h"
+
+namespace ozonewayland {
+
+// The WaylandDataOffer represents copy-and-paste or drag-and-drop data sent to
+// us by some Wayland client (possibly ourself).
+class WaylandDataOffer {
+ public:
+  // Takes ownership of data_offer.
+  explicit WaylandDataOffer(wl_data_offer* data_offer);
+
+  ~WaylandDataOffer();
+
+  const std::vector<std::string>&
+  GetAvailableMimeTypes() const { return mime_types_; }
+
+  // Indicate that |mime_type| can be accepted for the current (x, y) location
+  // of the drag. This might be used to change the cursor to indicate whether
+  // the drop will be accepted, for example. Does not cause any data to be
+  // transferred. |serial| is the value passed to WaylandDataDevice::OnEnter.
+  void Accept(uint32_t serial, const std::string& mime_type);
+  void Reject(uint32_t serial);
+
+  // Receive data of type mime_type from another Wayland client. Returns an open
+  // file descriptor to read the data from, or -1 on failure.
+  int Receive(const std::string& mime_type);
+
+ private:
+  static void OnOffer(void* data,
+                      wl_data_offer* data_offer,
+                      const char* mime_type);
+
+  wl_data_offer& data_offer_;
+  std::vector<std::string> mime_types_;
+
+  DISALLOW_COPY_AND_ASSIGN(WaylandDataOffer);
+};
+
+}  // namespace ozonewayland
+
+#endif  // OZONE_WAYLAND_DATA_OFFER_H_

--- a/wayland/display.cc
+++ b/wayland/display.cc
@@ -22,6 +22,7 @@
 #include "base/stl_util.h"
 #include "ipc/ipc_sender.h"
 #include "ozone/platform/messages.h"
+#include "ozone/wayland/data_device.h"
 #include "ozone/wayland/display_poll_thread.h"
 #include "ozone/wayland/egl/surface_ozone_wayland.h"
 #if defined(ENABLE_DRM_SUPPORT)
@@ -81,6 +82,7 @@ WaylandDisplay::WaylandDisplay() : SurfaceFactoryOzone(),
     display_(NULL),
     registry_(NULL),
     compositor_(NULL),
+    data_device_manager_(NULL),
     shell_(NULL),
     shm_(NULL),
     text_input_manager_(NULL),
@@ -332,6 +334,9 @@ void WaylandDisplay::Terminate() {
   if (text_input_manager_)
     wl_text_input_manager_destroy(text_input_manager_);
 
+  if (data_device_manager_)
+    wl_data_device_manager_destroy(data_device_manager_);
+
 #if defined(ENABLE_DRM_SUPPORT)
   if (m_deviceName)
     delete m_deviceName;
@@ -526,6 +531,23 @@ void WaylandDisplay::HideInputPanel() {
   primary_seat_->HideInputPanel();
 }
 
+void WaylandDisplay::RequestDragData(const std::string& mime_type) {
+  primary_seat_->GetDataDevice()->RequestDragData(mime_type);
+}
+
+void WaylandDisplay::RequestSelectionData(const std::string& mime_type) {
+  primary_seat_->GetDataDevice()->RequestSelectionData(mime_type);
+}
+
+void WaylandDisplay::DragWillBeAccepted(uint32_t serial,
+                                        const std::string& mime_type) {
+  primary_seat_->GetDataDevice()->DragWillBeAccepted(serial, mime_type);
+}
+
+void WaylandDisplay::DragWillBeRejected(uint32_t serial) {
+  primary_seat_->GetDataDevice()->DragWillBeRejected(serial);
+}
+
 #if defined(ENABLE_DRM_SUPPORT)
 void WaylandDisplay::DrmHandleDevice(const char* device) {
   drm_magic_t magic;
@@ -583,6 +605,9 @@ void WaylandDisplay::DisplayHandleGlobal(void *data,
   if (strcmp(interface, "wl_compositor") == 0) {
     disp->compositor_ = static_cast<wl_compositor*>(
         wl_registry_bind(registry, name, &wl_compositor_interface, 1));
+  } else if (strcmp(interface, "wl_data_device_manager") == 0) {
+    disp->data_device_manager_ = static_cast<wl_data_device_manager*>(
+        wl_registry_bind(registry, name, &wl_data_device_manager_interface, 1));
 #if defined(ENABLE_DRM_SUPPORT)
   } else if (!strcmp(interface, "wl_drm")) {
     m_drm = static_cast<struct wl_drm*>(wl_registry_bind(registry,
@@ -600,6 +625,10 @@ void WaylandDisplay::DisplayHandleGlobal(void *data,
     // (kalyan) Support extended output.
     disp->primary_screen_ = disp->screen_list_.front();
   } else if (strcmp(interface, "wl_seat") == 0) {
+    // TODO(mcatanzaro): The display passed to WaylandInputDevice must have a
+    // valid data device manager. We should ideally be robust to the compositor
+    // advertising a wl_seat first. No known compositor does this, fortunately.
+    CHECK(disp->data_device_manager_);
     WaylandSeat* seat = new WaylandSeat(disp, name);
     disp->seat_list_.push_back(seat);
     disp->primary_seat_ = disp->seat_list_.front();
@@ -637,6 +666,10 @@ bool WaylandDisplay::OnMessageReceived(const IPC::Message& message) {
   IPC_MESSAGE_HANDLER(WaylandDisplay_ImeReset, ResetIme)
   IPC_MESSAGE_HANDLER(WaylandDisplay_ShowInputPanel, ShowInputPanel)
   IPC_MESSAGE_HANDLER(WaylandDisplay_HideInputPanel, HideInputPanel)
+  IPC_MESSAGE_HANDLER(WaylandDisplay_RequestDragData, RequestDragData)
+  IPC_MESSAGE_HANDLER(WaylandDisplay_RequestSelectionData, RequestSelectionData)
+  IPC_MESSAGE_HANDLER(WaylandDisplay_DragWillBeAccepted, DragWillBeAccepted)
+  IPC_MESSAGE_HANDLER(WaylandDisplay_DragWillBeRejected, DragWillBeRejected)
   IPC_MESSAGE_UNHANDLED(handled = false)
   IPC_END_MESSAGE_MAP()
 
@@ -741,6 +774,34 @@ void WaylandDisplay::PreeditStart() {
 
 void WaylandDisplay::InitializeXKB(base::SharedMemoryHandle fd, uint32_t size) {
   Dispatch(new WaylandInput_InitializeXKB(fd, size));
+}
+
+void WaylandDisplay::DragEnter(unsigned windowhandle,
+                               float x,
+                               float y,
+                               const std::vector<std::string>& mime_types,
+                               uint32_t serial) {
+  Dispatch(new WaylandInput_DragEnter(windowhandle, x, y, mime_types, serial));
+}
+
+void WaylandDisplay::DragData(unsigned windowhandle,
+                              base::FileDescriptor pipefd) {
+  Dispatch(new WaylandInput_DragData(windowhandle, pipefd));
+}
+
+void WaylandDisplay::DragLeave(unsigned windowhandle) {
+  Dispatch(new WaylandInput_DragLeave(windowhandle));
+}
+
+void WaylandDisplay::DragMotion(unsigned windowhandle,
+                                float x,
+                                float y,
+                                uint32_t time) {
+  Dispatch(new WaylandInput_DragMotion(windowhandle, x, y, time));
+}
+
+void WaylandDisplay::DragDrop(unsigned windowhandle) {
+  Dispatch(new WaylandInput_DragDrop(windowhandle));
 }
 
 void WaylandDisplay::Dispatch(IPC::Message* message) {

--- a/wayland/display.cc
+++ b/wayland/display.cc
@@ -804,6 +804,19 @@ void WaylandDisplay::DragDrop(unsigned windowhandle) {
   Dispatch(new WaylandInput_DragDrop(windowhandle));
 }
 
+void WaylandDisplay::SelectionChanged(
+    const std::vector<std::string>& mime_types) {
+  Dispatch(new WaylandInput_SelectionChanged(mime_types));
+}
+
+void WaylandDisplay::SelectionData(base::FileDescriptor pipefd) {
+  Dispatch(new WaylandInput_SelectionData(pipefd));
+}
+
+void WaylandDisplay::SelectionCleared() {
+  Dispatch(new WaylandInput_SelectionCleared());
+}
+
 void WaylandDisplay::Dispatch(IPC::Message* message) {
   if (!loop_) {
     deferred_messages_.push(message);

--- a/wayland/display.h
+++ b/wayland/display.h
@@ -164,6 +164,9 @@ class WaylandDisplay : public ui::SurfaceFactoryOzone,
   void DragLeave(unsigned windowhandle);
   void DragMotion(unsigned windowhandle, float x, float y, uint32_t time);
   void DragDrop(unsigned windowhandle);
+  void SelectionChanged(const std::vector<std::string>& mime_types);
+  void SelectionData(base::FileDescriptor pipefd);
+  void SelectionCleared();
 
 #if defined(ENABLE_DRM_SUPPORT)
   // DRM related.

--- a/wayland/display.h
+++ b/wayland/display.h
@@ -84,6 +84,9 @@ class WaylandDisplay : public ui::SurfaceFactoryOzone,
   wl_compositor* GetCompositor() const { return compositor_; }
   struct wl_text_input_manager* GetTextInputManager() const;
 
+  wl_data_device_manager*
+  GetDataDeviceManager() const { return data_device_manager_; }
+
   int GetDisplayFd() const { return wl_display_get_fd(display_); }
   unsigned GetSerial() const { return serial_; }
   void SetSerial(unsigned serial) { serial_ = serial; }
@@ -151,6 +154,17 @@ class WaylandDisplay : public ui::SurfaceFactoryOzone,
   void PreeditEnd();
   void PreeditStart();
   void InitializeXKB(base::SharedMemoryHandle fd, uint32_t size);
+
+  void DragEnter(unsigned windowhandle,
+                 float x,
+                 float y,
+                 const std::vector<std::string>& mime_types,
+                 uint32_t serial);
+  void DragData(unsigned windowhandle, base::FileDescriptor pipefd);
+  void DragLeave(unsigned windowhandle);
+  void DragMotion(unsigned windowhandle, float x, float y, uint32_t time);
+  void DragDrop(unsigned windowhandle);
+
 #if defined(ENABLE_DRM_SUPPORT)
   // DRM related.
   void DrmHandleDevice(const char*);
@@ -197,6 +211,10 @@ class WaylandDisplay : public ui::SurfaceFactoryOzone,
   void ImeCaretBoundsChanged(gfx::Rect rect);
   void ShowInputPanel();
   void HideInputPanel();
+  void RequestDragData(const std::string& mime_type);
+  void RequestSelectionData(const std::string& mime_type);
+  void DragWillBeAccepted(uint32_t serial, const std::string& mime_type);
+  void DragWillBeRejected(uint32_t serial);
   // This handler resolves all server events used in initialization. It also
   // handles input device registration, screen registration.
   static void DisplayHandleGlobal(
@@ -218,6 +236,7 @@ class WaylandDisplay : public ui::SurfaceFactoryOzone,
   wl_display* display_;
   wl_registry* registry_;
   wl_compositor* compositor_;
+  wl_data_device_manager* data_device_manager_;
   WaylandShell* shell_;
   wl_shm* shm_;
   struct wl_text_input_manager* text_input_manager_;

--- a/wayland/seat.cc
+++ b/wayland/seat.cc
@@ -6,6 +6,7 @@
 #include "ozone/wayland/seat.h"
 
 #include "base/logging.h"
+#include "ozone/wayland/data_device.h"
 #include "ozone/wayland/display.h"
 #include "ozone/wayland/input/cursor.h"
 #include "ozone/wayland/input/keyboard.h"
@@ -34,10 +35,13 @@ WaylandSeat::WaylandSeat(WaylandDisplay* display,
   DCHECK(seat_);
   wl_seat_add_listener(seat_, &kInputSeatListener, this);
   wl_seat_set_user_data(seat_, this);
+
+  data_device_ = new WaylandDataDevice(display, seat_);
   text_input_ = new WaylandTextInput(this);
 }
 
 WaylandSeat::~WaylandSeat() {
+  delete data_device_;
   delete input_keyboard_;
   delete input_pointer_;
   delete text_input_;

--- a/wayland/seat.h
+++ b/wayland/seat.h
@@ -14,6 +14,7 @@
 
 namespace ozonewayland {
 
+class WaylandDataDevice;
 class WaylandKeyboard;
 class WaylandPointer;
 class WaylandDisplay;
@@ -26,6 +27,7 @@ class WaylandSeat {
   ~WaylandSeat();
 
   wl_seat* GetWLSeat() const { return seat_; }
+  WaylandDataDevice* GetDataDevice() const { return data_device_; }
   WaylandKeyboard* GetKeyBoard() const { return input_keyboard_; }
   WaylandPointer* GetPointer() const { return input_pointer_; }
   unsigned GetFocusWindowHandle() const { return focused_window_handle_; }
@@ -52,6 +54,7 @@ class WaylandSeat {
   unsigned grab_window_handle_;
   uint32_t grab_button_;
   struct wl_seat* seat_;
+  WaylandDataDevice* data_device_;
   WaylandKeyboard* input_keyboard_;
   WaylandPointer* input_pointer_;
   WaylandTouchscreen* input_touch_;

--- a/wayland/wayland.gyp
+++ b/wayland/wayland.gyp
@@ -79,6 +79,10 @@
         }],
       ],
       'sources': [
+        'data_device.cc',
+        'data_device.h',
+        'data_offer.cc',
+        'data_offer.h',
         'display.cc',
         'display.h',
         'display_poll_thread.cc',


### PR DESCRIPTION
This code isn't ready to merge yet, but it works.

Notes:

 * This depends on the DnD pull request.
 * The changes in `WindowManagerWayland` are littered with TODOs. I plan to rewrite that code. I'm posting this early for early feedback on the rest of the code.
 * The `ClipboardWayland` subclass isn't actually necessary yet (it's not doing anything that `ClipboardAura` can't do itself), but it's added anyway since it will be required for cut and copy.
 * I had trouble trying to add `ClipboardWayland` in the Ozone-Wayland repository, so it's done as a patch to Chrome. This is not very good. :(
 * For now, only plain text is supported. I intend to add support for most of the MIME types Chrome recognizes.