### PR TITLE
M46 gardening: Fix the Crosswalk linux tests broken by missing headers

### DIFF
--- a/patches/0007-Add-needed-support-in-PlatformWindow.patch
+++ b/patches/0007-Add-needed-support-in-PlatformWindow.patch
@@ -17,8 +17,8 @@ index a8fd6ee..93dae5b 100644
  
  #include "base/memory/scoped_ptr.h"
  #include "base/strings/string16.h"
-+#include "third_party/skia/include/core/SkPath.h"
  #include "ui/base/cursor/cursor.h"
++#include "ui/gfx/native_widget_types.h"
  
  namespace gfx {
  class Rect;


### PR DESCRIPTION
1.The SkPath.h include seems to be causing test build failure because it's
not able to find the SkTypes.h in the include path. So removing it.
2.native_widget_types.h is needed as we are using gfx::AcceleratedWidget