### PR TITLE
Only send activation events when activation changes

### DIFF
--- a/platform/window_manager_wayland.cc
+++ b/platform/window_manager_wayland.cc
@@ -140,6 +140,9 @@ void WindowManagerWayland::OnActivationChanged(unsigned windowhandle,
   }
 
   if (active) {
+    if (active_window_ && active_window_ == window)
+        return;
+
     if (current_capture_) {
       event_grabber_ = windowhandle;
       return;


### PR DESCRIPTION
This fixes an issue where a mouse button down event would show the
bookmark bubble and the mouse button up event would close it.