### PR TITLE
Fix OnKeyPress event.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@ Hongzhang Yan <hongzhang.yan@intel.com>
 Jiajia Qin <jiajia.qin@intel.com>
 Joone Hur <joone.hur@intel.com>
 José Bollo <jose.bollo@open.eurogiciel.org>
+Julien Brianceau <jbriance@cisco.com>
 Kalyan Kondapally <kalyan.kondapally@intel.com>
 Manuel Bachmann <manuel.bachmann@open.eurogiciel.org>
 Michael Catanzaro <mcatanzaro@igalia.com>

--- a/ui/desktop_aura/desktop_window_tree_host_ozone.cc
+++ b/ui/desktop_aura/desktop_window_tree_host_ozone.cc
@@ -865,7 +865,7 @@ void DesktopWindowTreeHostOzone::DispatchEvent(ui::Event* event) {
     case ui::ET_KEY_PRESSED:
     case ui::ET_KEY_RELEASED: {
       GetInputMethod()->DispatchKeyEvent(static_cast<ui::KeyEvent*>(event));
-      break;
+      return;
     }
 
     default:


### PR DESCRIPTION
The "Gardening: Adapt to https://codereview.chromium.org/1236923003"
commit (25315fc81890a54e49ea357b4ed0391eff868eb6) seems incomplete.
According to what has been done in desktop_window_tree_host_x11.cc,
we do not have to call SendEventToProcessor for keyboard events.
Also add myself in AUTHORS file.

The following test page can be used to monitor OnKeyPress event:
http://www.asquare.net/javascript/tests/KeyCode.html. Without this
patch, the backspace key is not working properly.