### PR TITLE
Fix multiple definition link error

### DIFF
--- a/ui/desktop_aura/desktop_factory_ozone_wayland.cc
+++ b/ui/desktop_aura/desktop_factory_ozone_wayland.cc
@@ -5,7 +5,7 @@
 #include "ozone/ui/desktop_aura/desktop_factory_ozone_wayland.h"
 
 #include "ozone/ui/desktop_aura/desktop_screen_wayland.h"
-#include "ozone/ui/desktop_aura/desktop_window_tree_host_ozone.cc"
+#include "ozone/ui/desktop_aura/desktop_window_tree_host_ozone.h"
 
 namespace views {
 


### PR DESCRIPTION
Include desktop_window_tree_host_ozone header instead of its implementation
in desktop_factory_ozone_wayland.cc to solve the following link issue:

  obj/ozone/ui/desktop_aura/views.desktop_window_tree_host_ozone.o: In function `views::DesktopWindowTreeHostOzone::AsWindowTreeHost()':
  src/ozone/ui/desktop_aura/desktop_window_tree_host_ozone.cc:239: multiple definition of `views::DesktopWindowTreeHostOzone::AsWindowTreeHost()'
  src/ozone/ui/desktop_aura/desktop_window_tree_host_ozone.cc:239: first defined here
  obj/ozone/ui/desktop_aura/views.desktop_window_tree_host_ozone.o: In function `views::DesktopWindowTreeHostOzone::ShowMaximizedWithBounds(gfx::Rect const&)':
  src/ozone/ui/desktop_aura/desktop_window_tree_host_ozone.cc:268: multiple definition of `views::DesktopWindowTreeHostOzone::ShowMaximizedWithBounds(gfx::Rect const&)'
  src/ozone/ui/desktop_aura/desktop_window_tree_host_ozone.cc:268: first defined here
  [...]