### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ That's all. At this point you should be able to connect Chromium on Weston using
   $ ~/git/weston/src/weston &
   $ ./out/Debug/chrome --no-sandbox --ignore-gpu-blacklist
   ```
-###Sandboxing
+### Sandboxing
 If you want to enable Sandboxing provided by Chromium, please follow the instructions from here:
 https://code.google.com/p/chromium/wiki/LinuxSUIDSandbox
 
-###Working with Ozone-Wayland Release branch:
+### Working with Ozone-Wayland Release branch:
 
 Instructions can be found here: https://github.com/01org/ozone-wayland/wiki/Releasing#wiki-releasebranch
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
